### PR TITLE
plugins: do not pass `--quiet` to `csgrep` for CBMC, Divine and Symbiotic

### DIFF
--- a/py/plugins/cbmc.py
+++ b/py/plugins/cbmc.py
@@ -122,10 +122,11 @@ class Plugin:
             src_dir = results.dbgdir_raw + CBMC_CAPTURE_DIR
             dst = "%s/cbmc-capture.js" % results.dbgdir_uni
             cmd = """
+                  set -ex
                   for file in %s/pid-*.out; do
-                      cat \"$file\" | cbmc-convert-output -a > \"$file.conv\";
-                  done;
-                  csgrep --mode=json --quiet --remove-duplicates '%s'/pid-*.out.conv > '%s'""" \
-                    % (src_dir, src_dir, dst)
+                      cbmc-convert-output -a < \"$file\" > \"$file.conv\"
+                  done
+                  csgrep --mode=json --remove-duplicates '%s'/pid-*.out.conv > '%s'
+                  """ % (src_dir, src_dir, dst)
             return results.exec_cmd(cmd, shell=True)
         props.post_process_hooks += [filter_hook]

--- a/py/plugins/divine.py
+++ b/py/plugins/divine.py
@@ -120,7 +120,9 @@ class Plugin:
         def filter_hook(results):
             src_dir = results.dbgdir_raw + DIVINE_CAPTURE_DIR
             dst = "%s/divine-capture.js" % results.dbgdir_uni
-            cmd = "csgrep --mode=json --quiet --remove-duplicates '%s'/pid-*.conv > '%s'" \
+            # TODO: We should do the conversion here as well but that can be
+            # done only after divine produces absolute paths reliably.
+            cmd = "csgrep --mode=json --remove-duplicates '%s'/pid-*.conv > '%s'" \
                   % (src_dir, dst)
             return results.exec_cmd(cmd, shell=True)
         props.post_process_hooks += [filter_hook]

--- a/py/plugins/symbiotic.py
+++ b/py/plugins/symbiotic.py
@@ -135,10 +135,11 @@ class Plugin:
             src_dir = results.dbgdir_raw + SYMBIOTIC_CAPTURE_DIR
             dst = "%s/symbiotic-capture.js" % results.dbgdir_uni
             cmd = """
+                  set -ex
                   for file in %s/pid-*.out; do
-                      symbiotic2cs < \"$file\" > \"$file.conv\";
-                  done;
-                  csgrep --mode=json --quiet --remove-duplicates '%s'/pid-*.out.conv > '%s'""" \
-                    % (src_dir, src_dir, dst)
+                      symbiotic2cs < \"$file\" > \"$file.conv\"
+                  done
+                  csgrep --mode=json --remove-duplicates '%s'/pid-*.out.conv > '%s'
+                  """ % (src_dir, src_dir, dst)
             return results.exec_cmd(cmd, shell=True)
         props.post_process_hooks += [filter_hook]


### PR DESCRIPTION
... so that we can spot errors in our converters more easily.  And fail if the conversion fails too.