### PR TITLE
csmock: assume plug-ins are experimental

### DIFF
--- a/py/csmock
+++ b/py/csmock
@@ -576,15 +576,22 @@ class PluginManager:
         max_key_len = max(map(len, self.plug_by_name.keys()))
         min_indent_len = 8
         description_indent = max_key_len + min_indent_len
-        for key, plugin in sorted(self.plug_by_name.items()):
-            props = plugin.get_props()
-            desc = getattr(props, "description", "")
-            if not getattr(props, "stable", False):
-                # highlight the fact that the plug-in is experimental
-                desc = "[EXPERIMENTAL] " + desc
-            sys.stdout.write("{}{}{}\n".format(
-                key, " " * (description_indent - len(key)),
-                desc.replace('\n', '\n%s' % (" " * description_indent))))
+
+        def list_plugins(stable):
+            for key, plugin in sorted(self.plug_by_name.items()):
+                props = plugin.get_props()
+                desc = getattr(props, "description", "")
+                if stable != getattr(props, "stable", False):
+                    continue
+                if not stable:
+                    # highlight the fact that the plug-in is experimental
+                    desc = "[EXPERIMENTAL] " + desc
+                sys.stdout.write("{}{}{}\n".format(
+                    key, " " * (description_indent - len(key)),
+                    desc.replace('\n', '\n%s' % (" " * description_indent))))
+
+        list_plugins(stable=True)
+        list_plugins(stable=False)
 
     def get_name_list(self):
         return sorted(self.plug_by_name.keys())

--- a/py/csmock
+++ b/py/csmock
@@ -579,7 +579,7 @@ class PluginManager:
         for key, plugin in sorted(self.plug_by_name.items()):
             props = plugin.get_props()
             desc = getattr(props, "description", "")
-            if getattr(props, "experimental", False):
+            if not getattr(props, "stable", False):
                 # highlight the fact that the plug-in is experimental
                 desc = "[EXPERIMENTAL] " + desc
             sys.stdout.write("{}{}{}\n".format(
@@ -595,8 +595,8 @@ class PluginManager:
 
     def enable_all(self):
         for plugin in self.plugins_sorted:
-            experimental= getattr(plugin.get_props(), "experimental", False)
-            if experimental:
+            stable = getattr(plugin.get_props(), "stable", False)
+            if not stable:
                 continue
             plugin.enable()
 
@@ -763,7 +763,7 @@ def main():
 
     parser.add_argument(
         "-a", "--all-tools", action="store_true",
-        help="enable all available tools \
+        help="enable all stable csmock plug-ins \
 (use --list-available-tools to see the list of available tools)")
 
     parser.add_argument(

--- a/py/plugins/bandit.py
+++ b/py/plugins/bandit.py
@@ -28,7 +28,6 @@ FILTER_CMD = "csgrep --quiet '%s' | csgrep --event '%s' > '%s'"
 class PluginProps:
     def __init__(self):
         self.description = "A tool designed to find common security issues in Python code."
-        self.experimental = True
 
 
 class Plugin:

--- a/py/plugins/cbmc.py
+++ b/py/plugins/cbmc.py
@@ -27,7 +27,6 @@ DEFAULT_CBMC_TIMEOUT = 42
 class PluginProps:
     def __init__(self):
         self.description = "Bounded Model Checker for C and C++ programs"
-        self.experimental = True
 
         # hook this plug-in before "gcc" to make ScanProps:enable_csexec() work
         self.pass_before = ["gcc"]

--- a/py/plugins/clang.py
+++ b/py/plugins/clang.py
@@ -28,6 +28,9 @@ class PluginProps:
     def __init__(self):
         self.description = "Source code analysis tool that finds bugs in C, C++, and Objective-C programs."
 
+        # include this plug-in in `csmock --all-tools`
+        self.stable = True
+
 
 class Plugin:
     def __init__(self):

--- a/py/plugins/cppcheck.py
+++ b/py/plugins/cppcheck.py
@@ -27,6 +27,9 @@ class PluginProps:
     def __init__(self):
         self.description = "Static analysis tool for C/C++ code."
 
+        # include this plug-in in `csmock --all-tools`
+        self.stable = True
+
 
 class Plugin:
     def __init__(self):

--- a/py/plugins/divine.py
+++ b/py/plugins/divine.py
@@ -28,7 +28,6 @@ DEFAULT_DIVINE_TIMEOUT = 150
 class PluginProps:
     def __init__(self):
         self.description = "A formal verification tool based on explicit-state model checking."
-        self.experimental = True
 
         # hook this plug-in before "gcc" to make ScanProps:enable_csexec() work
         self.pass_before = ["gcc"]

--- a/py/plugins/gcc.py
+++ b/py/plugins/gcc.py
@@ -29,6 +29,9 @@ class PluginProps:
     def __init__(self):
         self.description = "Plugin capturing GCC warnings, optionally with customized compiler flags."
 
+        # include this plug-in in `csmock --all-tools`
+        self.stable = True
+
 
 class Plugin:
     def __init__(self):

--- a/py/plugins/pylint.py
+++ b/py/plugins/pylint.py
@@ -29,8 +29,7 @@ FILTER_CMD = "csgrep --quiet '%s' " \
 
 class PluginProps:
     def __init__(self):
-        self.description = "Python source code analyzer which looks for programming errors.\n" \
-                           "Helps enforcing a coding standard and sniffs for some code smells."
+        self.description = "Python source code analyzer which looks for programming errors."
 
 
 class Plugin:

--- a/py/plugins/shellcheck.py
+++ b/py/plugins/shellcheck.py
@@ -31,6 +31,9 @@ class PluginProps:
     def __init__(self):
         self.description = "A static analysis tool that gives warnings and suggestions for bash/sh shell scripts."
 
+        # include this plug-in in `csmock --all-tools`
+        self.stable = True
+
 
 class Plugin:
     def __init__(self):

--- a/py/plugins/smatch.py
+++ b/py/plugins/smatch.py
@@ -25,7 +25,6 @@ import csmock.common.util
 
 class PluginProps:
     def __init__(self):
-        self.experimental = True
         self.description = "Source code analysis for C, based on sparse."
 
 

--- a/py/plugins/strace.py
+++ b/py/plugins/strace.py
@@ -24,7 +24,6 @@ STRACE_CAPTURE_DIR = "/builddir/strace-capture"
 
 class PluginProps:
     def __init__(self):
-        self.experimental = True
         self.description = "A dynamic analysis tool that records system calls associated with a running process."
 
         # hook this plug-in before "gcc" to make ScanProps:enable_csexec() work

--- a/py/plugins/symbiotic.py
+++ b/py/plugins/symbiotic.py
@@ -28,7 +28,6 @@ DEFAULT_SYMBIOTIC_TIMEOUT = 30 # TODO
 class PluginProps:
     def __init__(self):
         self.description = "A formal verification tool based on instrumentation, program slicing and KLEE."
-        self.experimental = True
 
         # hook this plug-in before "gcc" to make ScanProps:enable_csexec() work
         self.pass_before = ["gcc"]

--- a/py/plugins/valgrind.py
+++ b/py/plugins/valgrind.py
@@ -27,7 +27,6 @@ DEFAULT_VALGRIND_TIMEOUT = 30
 class PluginProps:
     def __init__(self):
         self.description = "A dynamic analysis tool for finding memory management bugs in programs."
-        self.experimental = True
 
         # hook this plug-in before "gcc" to make ScanProps:enable_csexec() work
         self.pass_before = ["gcc"]


### PR DESCRIPTION
... unless explicitly tagged as stable.  We have more experimental plug-ins than stable these days.  If someone forgot to tag a plug-in as experimental, it might have been enabled by mistake.  Assuming that untagged plug-ins are experimental is the safer approach here.