### PR TITLE
make-srpm.sh: make cbmc plug-in require cbmc-utils

### DIFF
--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -134,6 +134,7 @@ This package contains the bandit plug-in for csmock.
 
 %package -n csmock-plugin-cbmc
 Summary: csmock plug-in providing the support for cbmc
+Requires: cbmc-utils
 Requires: csexec
 Requires: csmock-common(python3)
 


### PR DESCRIPTION
The cbmc plug-in took care of installing cbmc-utils into buildroot
(mainly to make csexec work).  However its filter_hook() runs on the
host and uses cbmc-convert-output, which is provided by cbmc-utils.
Hence we need cbmc-utils installed also on the host.

Reported-by: Jerry James
Closes: https://github.com/csutils/csmock/pull/46