### PR TITLE
Symbiotic + Divine follow-up to #46

### DIFF
--- a/py/plugins/divine.py
+++ b/py/plugins/divine.py
@@ -119,8 +119,6 @@ class Plugin:
         def filter_hook(results):
             src_dir = results.dbgdir_raw + DIVINE_CAPTURE_DIR
             dst = "%s/divine-capture.js" % results.dbgdir_uni
-            # TODO: We should do the conversion here as well but that can be
-            # done only after divine produces absolute paths reliably.
             cmd = "csgrep --mode=json --remove-duplicates '%s'/pid-*.conv > '%s'" \
                   % (src_dir, dst)
             return results.exec_cmd(cmd, shell=True)

--- a/py/plugins/symbiotic.py
+++ b/py/plugins/symbiotic.py
@@ -116,8 +116,8 @@ class Plugin:
                  '-Wno-unused-parameter', '-Wno-unknown-attributes',
                  '-Wno-unused-label', '-Wno-unknown-pragmas',
                  '-Wno-unused-command-line-argument',
-                 '-Xclang', '-fsanitize-address-use-after-scope',
-                 '-O0', '-disable-llvm-passes', '-D__inline=', '-g',
+                 '-fsanitize-address-use-after-scope', '-O0', '-Xclang',
+                 '-disable-llvm-passes', '-D__inline=', '-g',
                  '-Wl,--dynamic-linker,/usr/bin/csexec-loader']
         self.flags.append_flags(flags)
         self.flags.remove_flags(['-O1', '-O2', '-O3', '-Os', '-Ofast', '-Og'])

--- a/py/plugins/symbiotic.py
+++ b/py/plugins/symbiotic.py
@@ -133,12 +133,7 @@ class Plugin:
         def filter_hook(results):
             src_dir = results.dbgdir_raw + SYMBIOTIC_CAPTURE_DIR
             dst = "%s/symbiotic-capture.js" % results.dbgdir_uni
-            cmd = """
-                  set -ex
-                  for file in %s/pid-*.out; do
-                      symbiotic2cs < \"$file\" > \"$file.conv\"
-                  done
-                  csgrep --mode=json --remove-duplicates '%s'/pid-*.out.conv > '%s'
-                  """ % (src_dir, src_dir, dst)
+            cmd = "csgrep --mode=json --remove-duplicates '%s'/pid-*.conv > '%s'" \
+                  % (src_dir, dst)
             return results.exec_cmd(cmd, shell=True)
         props.post_process_hooks += [filter_hook]


### PR DESCRIPTION
Do not require any tools that are not available in official Fedora repositories and fix `gclang`'s really annoying warnings about `-disable-llvm-passes` option.