### PR TITLE
divine: tweak arguments passed to Divine

### DIFF
--- a/py/plugins/divine.py
+++ b/py/plugins/divine.py
@@ -91,7 +91,10 @@ class Plugin:
                 "--skip-ld-linux",
                 "csexec-divine",
                 "-l", DIVINE_CAPTURE_DIR,
-                "-d", "check --max-time %d" % args.divine_timeout]
+                # --lart stubs replaces undefined functions with stubs
+                # -o ignore:exit ignores non-zero exit codes
+                "-d", "check --lart stubs -o ignore:exit --max-time %d" \
+                      % args.divine_timeout]
 
         # append custom args if specified
         # FIXME: what about single arguments with whitespaces?


### PR DESCRIPTION
* `--lart stubs` - Transform all undefined functions into stubs, e.g. Divine will fail if a call to such function is reachable.  Previously, Divine even refused to start if any (e.g. unreachable) undefined function was present in the module.
* `-o exit:ignore` - Do not classify non-zero exit code as an error.