### PR TITLE
divine: optionally require `glibc-devel(x86-32)`

### DIFF
--- a/py/plugins/divine.py
+++ b/py/plugins/divine.py
@@ -61,6 +61,9 @@ class Plugin:
         props.add_repos += ["https://download.copr.fedorainfracloud.org/results/@aufover/divine/fedora-$releasever-$basearch/"]
         props.install_pkgs += ["divine"]
 
+        # dioscc seems to require /usr/include/gnu/stubs-32.h
+        props.install_opt_pkgs += ["glibc-devel(x86-32)"]
+
         # enable cswrap
         props.enable_cswrap()
         props.cswrap_filters += ["csgrep --mode=json --invert-match --checker CLANG_WARNING --event error"]


### PR DESCRIPTION
... to fix unnecessary build failure of findutils-4.8.0-4.fc35:
```
26: In file included from /builddir/build/BUILD/findutils-4.8.0/lib/fdleak.c:25: <--[dioscc]
26: In file included from /usr/include/poll.h:1: <--[dioscc]
26: In file included from /usr/include/sys/poll.h:22: <--[dioscc]
26: In file included from /usr/include/features.h:512: <--[dioscc]
26: /usr/include/gnu/stubs.h:7:11: fatal error: 'gnu/stubs-32.h' file not found <--[dioscc]
26: # include <gnu/stubs-32.h>
26:           ^~~~~~~~~~~~~~~~
```
Unfortunately, the build fails with many unrelated errors anyway.