### PR TITLE
symbiotic: set timeout also for sbt-inst and slicer

### DIFF
--- a/py/plugins/symbiotic.py
+++ b/py/plugins/symbiotic.py
@@ -94,11 +94,12 @@ class Plugin:
         props.post_depinst_hooks += [create_cap_dir_hook]
 
         # default symbiotic cmd-line
+        timeout = args.symbiotic_timeout
         wrap_cmd_list = [
                 "--skip-ld-linux",
                 "csexec-symbiotic",
                 "-l", SYMBIOTIC_CAPTURE_DIR,
-                "-s", "--prp=memsafety --timeout=%d" % args.symbiotic_timeout]
+                "-s", f"--prp=memsafety --timeout={timeout} --instrumentation-timeout={timeout} --slicer-timeout={timeout}"]
 
         # append custom args if specified
         # FIXME: what about single arguments with whitespaces?


### PR DESCRIPTION
Otherwise symbiotic may run for a couple of minutes despite we invoke csmock with `--symbiotic-timeout` set to a couple of seconds.