### PR TITLE
symbiotic: patch symbiotic to use /usr/bin/timeout

### DIFF
--- a/scripts/chroot-fixups/symbiotic-timeout.sh
+++ b/scripts/chroot-fixups/symbiotic-timeout.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+for file in /opt/symbiotic/lib/symbioticpy/symbiotic/{transform,verifier}.py; do
+    [ -w ${file} ] || continue
+
+    # Make sure that symbiotic uses the system-provided timeout(1) for itself.
+    # Otherwise, when formally verifying the coreutils RPM package by Symbiotic,
+    # the test-suite puts our instrumented binary of timeout(1) into ${PATH},
+    # causing it to recursively invoke whole symbiotic on each invocation of
+    # timeout within symbiotic.
+    (
+        set -x
+        sed -e "s|'timeout'|'/usr/bin/timeout'|" -i ${file}
+    )
+done


### PR DESCRIPTION
Make sure that symbiotic uses the system-provided timeout(1) for itself.
Otherwise, when formally verifying the coreutils RPM package by Symbiotic,
the test-suite puts our instrumented binary of timeout(1) into ${PATH},
causing it to recursively invoke whole symbiotic on each invocation of
timeout within symbiotic.