### PR TITLE
plugins: avoid `csgrep: Argument list too long` error

### DIFF
--- a/py/plugins/divine.py
+++ b/py/plugins/divine.py
@@ -124,8 +124,12 @@ class Plugin:
         # transform log files produced by divine into csdiff format
         def filter_hook(results):
             src_dir = results.dbgdir_raw + DIVINE_CAPTURE_DIR
-            dst = "%s/divine-capture.js" % results.dbgdir_uni
-            cmd = "csgrep --mode=json --remove-duplicates '%s'/pid-*.conv > '%s'" \
-                  % (src_dir, dst)
+
+            # ensure we have permission to read all capture files
+            results.exec_cmd(['chmod', '-R', '+r', src_dir])
+
+            # `cd` first to avoid `csgrep: Argument list too long` error on glob expansion
+            dst = f"{results.dbgdir_uni}/divine-capture.js"
+            cmd = f"cd '{src_dir}' && csgrep --mode=json --remove-duplicates pid-*.conv > '{dst}'"
             return results.exec_cmd(cmd, shell=True)
         props.post_process_hooks += [filter_hook]

--- a/py/plugins/symbiotic.py
+++ b/py/plugins/symbiotic.py
@@ -133,8 +133,12 @@ class Plugin:
         # transform log files produced by symbiotic into csdiff format
         def filter_hook(results):
             src_dir = results.dbgdir_raw + SYMBIOTIC_CAPTURE_DIR
-            dst = "%s/symbiotic-capture.js" % results.dbgdir_uni
-            cmd = "csgrep --mode=json --remove-duplicates '%s'/pid-*.conv > '%s'" \
-                  % (src_dir, dst)
+
+            # ensure we have permission to read all capture files
+            results.exec_cmd(['chmod', '-R', '+r', src_dir])
+
+            # `cd` first to avoid `csgrep: Argument list too long` error on glob expansion
+            dst = f"{results.dbgdir_uni}/symbiotic-capture.js"
+            cmd = f"cd '{src_dir}' && csgrep --mode=json --remove-duplicates pid-*.conv > {dst}"
             return results.exec_cmd(cmd, shell=True)
         props.post_process_hooks += [filter_hook]

--- a/py/plugins/valgrind.py
+++ b/py/plugins/valgrind.py
@@ -112,8 +112,12 @@ class Plugin:
         # transform XML files produced by valgrind into csdiff format
         def filter_hook(results):
             src_dir = results.dbgdir_raw + VALGRIND_CAPTURE_DIR
-            dst = "%s/valgrind-capture.js" % results.dbgdir_uni
-            cmd = "csgrep --mode=json --quiet --remove-duplicates '%s'/*.xml > '%s'" \
-                    % (src_dir, dst)
+
+            # ensure we have permission to read all capture files
+            results.exec_cmd(['chmod', '-R', '+r', src_dir])
+
+            # `cd` first to avoid `csgrep: Argument list too long` error on glob expansion
+            dst = f"{results.dbgdir_uni}/valgrind-capture.js"
+            cmd = f"cd '{src_dir}' && csgrep --mode=json --quiet --remove-duplicates *.xml > '{dst}'"
             return results.exec_cmd(cmd, shell=True)
         props.post_process_hooks += [filter_hook]


### PR DESCRIPTION
... on glob expansion in filter_hook() and make sure we have read
permission on the capture files in case they were created with too
restrictive umask.