### PR TITLE
cbmc,divine: use 30s timeout by default

### DIFF
--- a/py/plugins/cbmc.py
+++ b/py/plugins/cbmc.py
@@ -21,7 +21,7 @@ from csmock.common.cflags import flags_by_warning_level
 
 CBMC_CAPTURE_DIR = "/builddir/cbmc-capture"
 
-DEFAULT_CBMC_TIMEOUT = 42
+DEFAULT_CBMC_TIMEOUT = 30
 
 
 class PluginProps:

--- a/py/plugins/divine.py
+++ b/py/plugins/divine.py
@@ -22,7 +22,7 @@ from csmock.common.cflags import flags_by_warning_level
 
 DIVINE_CAPTURE_DIR = "/builddir/divine-capture"
 
-DEFAULT_DIVINE_TIMEOUT = 150
+DEFAULT_DIVINE_TIMEOUT = 30
 
 
 class PluginProps:

--- a/py/plugins/symbiotic.py
+++ b/py/plugins/symbiotic.py
@@ -22,7 +22,7 @@ from csmock.common.cflags import flags_by_warning_level
 
 SYMBIOTIC_CAPTURE_DIR = "/builddir/symbiotic-capture"
 
-DEFAULT_SYMBIOTIC_TIMEOUT = 30 # TODO
+DEFAULT_SYMBIOTIC_TIMEOUT = 30
 
 
 class PluginProps:


### PR DESCRIPTION
... to make this consistent across all csmock plug-ins