### PR TITLE
cbmc: do not convert the outputs on host

### DIFF
--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -134,7 +134,6 @@ This package contains the bandit plug-in for csmock.
 
 %package -n csmock-plugin-cbmc
 Summary: csmock plug-in providing the support for cbmc
-Requires: cbmc-utils
 Requires: csexec
 Requires: csmock-common(python3)
 

--- a/py/plugins/cbmc.py
+++ b/py/plugins/cbmc.py
@@ -125,15 +125,8 @@ class Plugin:
 
             # `cd` first to avoid `csgrep: Argument list too long` error on glob expansion
             dst = f"{results.dbgdir_uni}/cbmc-capture.js"
-            cmd = f"""
-                  set -ex
-                  cd '{src_dir}'
-                  shopt -s nullglob
-                  for file in pid-*.out; do
-                      cbmc-convert-output -a < \"$file\" > \"$file.conv\"
-                  done
-                  touch empty.err
-                  csgrep --mode=json --remove-duplicates empty.err pid-*.out.conv > '{dst}'
-                  """
+            
+            cmd = f"csgrep --mode=json --remove-duplicates {src_dir}/pid-*.conv > {dst}"
+            
             return results.exec_cmd(cmd, shell=True)
         props.post_process_hooks += [filter_hook]

--- a/py/plugins/cbmc.py
+++ b/py/plugins/cbmc.py
@@ -126,7 +126,7 @@ class Plugin:
             # `cd` first to avoid `csgrep: Argument list too long` error on glob expansion
             dst = f"{results.dbgdir_uni}/cbmc-capture.js"
             
-            cmd = f"csgrep --mode=json --remove-duplicates {src_dir}/pid-*.conv > {dst}"
+            cmd = f"cd '{src_dir}' && touch empty.conv && csgrep --mode=json --remove-duplicates *.conv > '{dst}'"
             
             return results.exec_cmd(cmd, shell=True)
         props.post_process_hooks += [filter_hook]


### PR DESCRIPTION
This change is similar to https://github.com/csutils/csmock/pull/47.
I move the conversion into cbmc-utils/csexec-cbmc.sh: https://github.com/aufover/cbmc-utils/commit/f7b4f2ec40d8c2ed2179de83a936710911a21899.