### PR TITLE
csmock: install optional pkgs one by one

### DIFF
--- a/py/csmock
+++ b/py/csmock
@@ -1151,7 +1151,8 @@ the package.  Use --tools or --all-tools to enable them!\n", ec=0)
 
                 # install optional packages (if any)
                 if props.install_opt_pkgs:
-                    mock.try_install(props.install_opt_pkgs)
+                    for pkg in props.install_opt_pkgs:
+                        mock.try_install([pkg])
                     # just to update rpm-list-mock.txt
                     find_missing_pkgs([], results, mock)
 


### PR DESCRIPTION
If we run `mock --install csdiff compat-openssl11` and `compat-openssl11` is not available, it results in a failed transaction and none of them is installed.

If we run `mock --install` for each package separately, it will install everything that is possible to install.  `mock --install --skip-broken` would be more efficient but it is not available.