### PR TITLE
Add Shell linter - Differential-ShellCheck

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+---
+
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    reviewers:
+      - lzaoral

--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -1,0 +1,28 @@
+---
+
+name: Differential ShellCheck
+on:
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+      pull-requests: write
+
+    steps: 
+      - name: Repository checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Differential ShellCheck
+        uses: redhat-plumbers-in-action/differential-shellcheck@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Differential ShellCheck is a GitHub action that performs differential ShellCheck scans on files changed via PR and reports results directly in PR.

Since this repository contains some shell scripts I think you might find it useful.

Documentation is available at: [@redhat-plumbers-in-action/differential-shellcheck](https://github.com/redhat-plumbers-in-action/differential-shellcheck#readme). Let me know If you are missing some feature or setting.

/cc @kdudka 