### PR TITLE
gcc: make sure gcc is installed in the chroot

### DIFF
--- a/py/plugins/gcc.py
+++ b/py/plugins/gcc.py
@@ -172,6 +172,9 @@ class Plugin:
         if self.sanitize and "valgrind" in props.install_pkgs:
             parser.error("GCC sanitizers are not compatible with valgrind")
 
+        # make sure gcc is installed in the chroot
+        props.install_pkgs += ["gcc"]
+
         props.enable_cswrap()
         props.cswrap_filters += \
             ["csgrep --mode=json --invert-match --checker COMPILER_WARNING --event error"]


### PR DESCRIPTION
... to avoid a version hook failure in case gcc is not a build dependency of the scanned artifact:
```
!!! 2022-11-03 15:00:19	error: tool "gcc" does not seem to be installed in build root

!!! 2022-11-03 15:00:19	error: post-depinst hook failed
```

Closes: https://github.com/csutils/csmock/pull/79