### PR TITLE
bandit: write debug output to stderr

### DIFF
--- a/scripts/run-bandit.sh
+++ b/scripts/run-bandit.sh
@@ -6,8 +6,8 @@ SEC_LEVEL=$1
 shift
 
 # Debug
-echo "[DEBUG]	SEC_LEVEL = $SEC_LEVEL"
-echo "[DEBUG]	TARGET_PATH = $*"
+echo "[DEBUG]	SEC_LEVEL = $SEC_LEVEL" >&2
+echo "[DEBUG]	TARGET_PATH = $*" >&2
 
 if [[ -z "${SEC_LEVEL// }" ]]; then
 	echo "[ERROR]	SEC_LEVEL parameter is empty" >&2


### PR DESCRIPTION
... to prevent parsing errors while processing the capture later on:
```
$ head -3 xxx/debug/raw-results/builddir/bandit-capture.err
[DEBUG] SEC_LEVEL = -l
[DEBUG] TARGET_PATH = /builddir/build/BUILD
/builddir/build/BUILD/py/common/results.py:28: B404[bandit]: LOW: Consider possible security implications associated with the subprocess module.

$ csgrep xxx/debug/raw-results/builddir/bandit-capture.err
xxx/debug/raw-results/builddir/bandit-capture.err:1: error: expected value
```

Closes: https://github.com/csutils/csmock/pull/80