### PR TITLE
IniWriter: strip white-spaces from the given values

### DIFF
--- a/py/common/results.py
+++ b/py/common/results.py
@@ -260,7 +260,8 @@ class IniWriter:
         self.results.log_fd.write("scan.ini: " + text)
 
     def append(self, key, value):
-        self.write("%s = %s\n" % (key, value))
+        val_str = str(value).strip()
+        self.write("%s = %s\n" % (key, val_str))
 
 
 def transform_results(js_file, results):


### PR DESCRIPTION
The gitleaks plug-in was putting a trailing newline in the version string, which by mistake leaked into the resulting scan.ini file:
```
[scan]
tool = csmock
tool-version = csmock-3.3.5.20230201.102357.g903bf79.pr_87-1.fc36
tool-args = '/usr/bin/csmock' '-r' 'fedora-37-x86_64' '-f' '/home/kdudka/git/csmock/csmock-3.3.5.20230202.094355.g16818ee.dirty-1.fc36.src.rpm' '-t' 'unicontrol,gitleaks'
host = f36
store-results-to = /home/kdudka/git/csmock/csmock-3.3.5.20230202.094355.g16818ee.dirty-1.fc36.tar.xz
time-created = 2023-02-03 16:58:21
enabled-plugins = gitleaks, unicontrol
mock-config = fedora-37-x86_64
project-name = csmock-3.3.5.20230202.094355.g16818ee.dirty-1.fc36
known-false-positives = /usr/share/csmock/known-false-positives.js
analyzer-version-gitleaks = 8.15.1

analyzer-version-unicontrol = 0.0.2
time-finished = 2023-02-03 17:00:09
exit-code = 0
```

Rather than fixing each plug-in separately, we can always strip the string in IniWriter because the INI format does not work well with trailing white-spaces anyway.