### PR TITLE
run-shellcheck.sh: do not escape `#` and `!` for grep

### DIFF
--- a/scripts/run-shellcheck.sh
+++ b/scripts/run-shellcheck.sh
@@ -11,7 +11,7 @@ filter_shell_scripts() {
         fi
 
         # match by shebang
-        RE_SHEBANG='^\s*((\#|\!)|(\#\s*\!)|(\!\s*\#))\s*(/usr(/local)?)?/bin/(env\s+)?(ash|bash|bats|dash|ksh|sh)\b'
+        RE_SHEBANG='^\s*((#|!)|(#\s*!)|(!\s*#))\s*(/usr(/local)?)?/bin/(env\s+)?(ash|bash|bats|dash|ksh|sh)\b'
         if head -n1 "$i" | grep --text -E "$RE_SHEBANG" >/dev/null; then
             readlink -f "$i"
         fi


### PR DESCRIPTION
... to avoid excessive warnings printed in the log with grep-3.9-1.fc39:
```
$ /usr/share/csmock/scripts/run-shellcheck.sh
grep: warning: stray \ before #
grep: warning: stray \ before !
grep: warning: stray \ before #
grep: warning: stray \ before !
grep: warning: stray \ before !
grep: warning: stray \ before #
grep: warning: stray \ before #
grep: warning: stray \ before !
grep: warning: stray \ before #
grep: warning: stray \ before !
grep: warning: stray \ before !
grep: warning: stray \ before #
grep: warning: stray \ before #
grep: warning: stray \ before !
grep: warning: stray \ before #
grep: warning: stray \ before !
grep: warning: stray \ before !
[...]
```

Closes: https://github.com/csutils/csmock/pull/101