### PR TITLE
csmock: pass `props` reference to `pre_mock_hooks`

### DIFF
--- a/py/csmock
+++ b/py/csmock
@@ -1117,7 +1117,7 @@ the package.  Use --tools or --all-tools to enable them!\n", ec=0)
 
             # run pre-mock hooks
             for hook in props.pre_mock_hooks:
-                rv = hook(results)
+                rv = hook(results, props)
                 if rv != 0:
                     results.error("pre-mock hook failed", ec=rv)
 

--- a/py/plugins/gitleaks.py
+++ b/py/plugins/gitleaks.py
@@ -81,7 +81,7 @@ class Plugin:
             return
 
         # fetch gitleaks using the given URL
-        def fetch_gitleaks_hook(results):
+        def fetch_gitleaks_hook(results, props):
             cache_dir = args.gitleaks_cache_dir
             try:
                 # make sure the cache directory exists

--- a/py/plugins/snyk.py
+++ b/py/plugins/snyk.py
@@ -77,7 +77,7 @@ class Plugin:
             parser.error("unable to read snyk authentication token: %s" % self.auth_token_src)
 
         # fetch snyk using the given URL
-        def fetch_snyk_hook(results):
+        def fetch_snyk_hook(results, props):
             cache_dir = args.snyk_cache_dir
             try:
                 # make sure the cache directory exists

--- a/py/plugins/unicontrol.py
+++ b/py/plugins/unicontrol.py
@@ -61,7 +61,7 @@ class Plugin:
             return
 
         # update scan metadata
-        def write_toolver_hook(results):
+        def write_toolver_hook(results, _props):
             results.ini_writer.append("analyzer-version-unicontrol", "0.0.2")
             return 0
         props.pre_mock_hooks += [write_toolver_hook]


### PR DESCRIPTION
The pre-mock hooks of the gitleaks and snyk plug-ins used a stale `props` reference given to `handle_args`, which prevented them from working with `csmock --diff-patches`, which creates a deep copy of `props` for the baseline scan.

Closes: https://github.com/csutils/csmock/pull/102