### PR TITLE
gitleaks: install the plug-in by default

### DIFF
--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -102,6 +102,7 @@ BuildRequires: python%{python3_pkgversion}-devel
 Requires: csmock-common                 >= %{version}-%{release}
 Requires: csmock-plugin-clang           >= %{version}-%{release}
 Requires: csmock-plugin-cppcheck        >= %{version}-%{release}
+Requires: csmock-plugin-gitleaks        >= %{version}-%{release}
 Requires: csmock-plugin-shellcheck      >= %{version}-%{release}
 
 BuildArch: noarch

--- a/py/plugins/gitleaks.py
+++ b/py/plugins/gitleaks.py
@@ -41,6 +41,9 @@ class PluginProps:
     def __init__(self):
         self.description = "Tool for finding secrets in source code."
 
+        # include this plug-in in `csmock --all-tools`
+        self.stable = True
+
 
 class Plugin:
     def __init__(self):


### PR DESCRIPTION
... and enable it with `--all-tools`.  The plug-in has been enabled in production OpenScanHub since November 2022 and did not cause any major problems (except issue #98 which was fixed via pull request #100).

Closes: https://github.com/csutils/csmock/pull/104