### PR TITLE
csmock: be less verbose while extracting source tarballs

### DIFF
--- a/py/csmock
+++ b/py/csmock
@@ -1222,7 +1222,7 @@ cd %%s*/ || cd *\n\
                             prep_cmd_tpl = "unzip -d '%s' '%s'"
                         else:
                             # assume TAR
-                            prep_cmd_tpl = "tar -C '%s' -xvf '%s'"
+                            prep_cmd_tpl = "tar -C '%s' -xf '%s'"
                         prep_cmd = prep_cmd_tpl % ("/builddir/build/BUILD", src_tar_dup)
                         ec = mock.exec_mockbuild_cmd(prep_cmd)
 


### PR DESCRIPTION
Some source tarballs contain a huge number of files and the verbose output of tar unnecessarily pollutes `scan.log`.