### PR TITLE
Fix missing dependency

### DIFF
--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -128,6 +128,9 @@ Requires: csdiff > 3.0.3
 Requires: csgcca
 Requires: cswrap
 Requires: mock
+%if 0%{?rhel} != 7
+Recommends: modulemd-tools
+%endif
 
 %description -n csmock-common
 This package contains the csmock tool that allows to scan SRPMs by Static


### PR DESCRIPTION
The `bld2repo` executive is being used, but corresponding package
`modulemd-tools` was not declared as a dependency earlier.