### PR TITLE
csmock: drop `DEFAULT_KNOWN_FALSE_POSITIVES_FALLBACK`

### DIFF
--- a/py/csmock
+++ b/py/csmock
@@ -53,9 +53,6 @@ PATCH_RAWBUILD = CSMOCK_SCRIPTS + "/patch-rawbuild.sh"
 
 DEFAULT_KNOWN_FALSE_POSITIVES = CSMOCK_DATADIR + "/known-false-positives.js"
 
-# original name of the file, which could have sounded offensive to people
-DEFAULT_KNOWN_FALSE_POSITIVES_FALLBACK = CSMOCK_DATADIR + "/defect-blacklist.err"
-
 # how long should we wait before checking mock profile availability again
 MOCK_WAITING_TICK = 60
 
@@ -900,9 +897,6 @@ key event (defaults to 3).")
     # --known-false-positives
     if os.path.exists(DEFAULT_KNOWN_FALSE_POSITIVES):
         default_kfp = DEFAULT_KNOWN_FALSE_POSITIVES
-        default_kfp_text = " (defaults to \"%s\")" % default_kfp
-    elif os.path.exists(DEFAULT_KNOWN_FALSE_POSITIVES_FALLBACK):
-        default_kfp = DEFAULT_KNOWN_FALSE_POSITIVES_FALLBACK
         default_kfp_text = " (defaults to \"%s\")" % default_kfp
     else:
         default_kfp = ""

--- a/py/csmock
+++ b/py/csmock
@@ -895,15 +895,14 @@ key event (defaults to 3).")
         help="use shell command to build the given tarball (instead of SRPM)")
 
     # --known-false-positives
-    if os.path.exists(DEFAULT_KNOWN_FALSE_POSITIVES):
-        default_kfp = DEFAULT_KNOWN_FALSE_POSITIVES
-        default_kfp_text = " (defaults to \"%s\")" % default_kfp
-    else:
+    default_kfp = DEFAULT_KNOWN_FALSE_POSITIVES
+    default_kfp_text = f'defaults to "{default_kfp}"'
+    if not os.path.exists(default_kfp):
         default_kfp = ""
-        default_kfp_text = " (defaults to \"%s\" if available)" % DEFAULT_KNOWN_FALSE_POSITIVES
+        default_kfp_text += " if available"
     parser.add_argument(
         "--known-false-positives", default=default_kfp,
-        help=("suppress known false positives loaded from the given file" + default_kfp_text))
+        help=f"suppress known false positives loaded from the given file ({default_kfp_text})")
 
     csmock.common.util.add_paired_flag(
         parser, "use-login-shell",


### PR DESCRIPTION
The default path was renamed more than 2 years ago.  Nobody should use the fallback path any more.

Related: commit d7afe41f351c9dc18d71fe21683342bedba7d7ce