### PR TITLE
plugins: report an error if the version hook fails

### DIFF
--- a/py/plugins/cppcheck.py
+++ b/py/plugins/cppcheck.py
@@ -101,9 +101,10 @@ class Plugin:
 
         def store_cppcheck_version_hook(results, mock):
             cmd = mock.get_mock_cmd(["--chroot", "cppcheck --version"])
-            (rc, verstr) = results.get_cmd_output(cmd, shell=False)
-            if rc != 0:
-                return rc
+            (ec, verstr) = results.get_cmd_output(cmd, shell=False)
+            if ec != 0:
+                results.error("failed to query cppcheck version", ec=ec)
+                return ec
 
             ver = re.sub("^Cppcheck ", "", verstr.strip())
             results.ini_writer.append("analyzer-version-cppcheck", ver)

--- a/py/plugins/gitleaks.py
+++ b/py/plugins/gitleaks.py
@@ -125,6 +125,7 @@ class Plugin:
             # query version of gitleaks
             (ec, out) = results.get_cmd_output([gitleaks_bin, 'version'], shell=False)
             if 0 != ec:
+                results.error("failed to query gitleaks version", ec=ec)
                 return ec
 
             ver = re.sub("^v", "", out)

--- a/py/plugins/snyk.py
+++ b/py/plugins/snyk.py
@@ -110,6 +110,7 @@ class Plugin:
             # query version of snyk
             (ec, out) = results.get_cmd_output([self.snyk_bin, 'version'], shell=False)
             if 0 != ec:
+                results.error("failed to query snyk version", ec=ec)
                 return ec
 
             # parse and record the version of snyk


### PR DESCRIPTION
Otherwise, it is unclear which plug-in actually failed the scan:
```
[...]
>>> 2023-09-14 15:21:46	"'/usr/bin/mock' '-r' 'rhel-8.7.0.z-x86_64' '--plugin-option=tmpfs:keep_mounted=True' '--config-opts=print_main_output=True' '--quiet' '--shell' 'rpm -qa' | sort -V > /tmp/csmocktfv6f2ww/output/debug/rpm-list-mock.txt"

>>> 2023-09-14 15:21:48	"'/usr/bin/mock' '-r' 'rhel-8.7.0.z-x86_64' '--plugin-option=tmpfs:keep_mounted=True' '--config-opts=print_main_output=True' '--quiet' '--shell' 'rpm -qa --provides' | sort -V > /tmp/csmocktfv6f2ww/rpm-list-mock-provides.txt"

>>> 2023-09-14 15:21:50	"tar -cP '/usr/share/csmock/scripts' '/usr/bin/cswrap' '/usr/lib64/cswrap' '/usr/bin/csclng' '/usr/lib64/csclng' '/usr/bin/csclng++' '/usr/bin/cscppc' '/usr/lib64/cscppc' '/usr/share/cscppc' '/usr/bin/cppcheck' '/usr/share/Cppcheck' '/usr/bin/csgcca' '/usr/lib64/csgcca' '/tmp/csmocktfv6f2ww/gitleaks' | '/usr/bin/mock' '-r' 'rhel-8.7.0.z-x86_64' '--plugin-option=tmpfs:keep_mounted=True' '--config-opts=print_main_output=True' '--quiet' '--shell' 'tar -xC/'"
tar: Removing leading `/' from member names

scan.ini: analyzer-version-clang = 14.0.6
!!! 2023-09-14 15:21:54	error: post-depinst hook failed

>>> 2023-09-14 15:21:54	"/usr/bin/mock" "-r" "rhel-8.7.0.z-x86_64" "--plugin-option=tmpfs:keep_mounted=True" "--config-opts=print_main_output=True" "--quiet" "--clean"

scan.ini: time-finished = 2023-09-14 15:21:57
scan.ini: exit-code = 127
<<< 2023-09-14 15:21:57	csmock exit code: 127
```