### PR TITLE
csmock: log the command that applies props.cswrap_filters

### DIFF
--- a/py/csmock
+++ b/py/csmock
@@ -509,8 +509,8 @@ class ScanProps:
         for filt in self.cswrap_filters:
             cmd += " | %s" % filt
         cmd += " > '%s'" % out
-        (rv, _) = results.get_cmd_output(cmd)
-        return rv
+        return results.exec_cmd(cmd, shell=True)
+
 
     def wrap_build_cmd(self, cmd_in):
         cmd_out = cmd_in


### PR DESCRIPTION
If `csgrep` fails to run in the host environment, it is not clear from the log how the failing command looked like, as for example:
```
[...]
>>> 2023-09-25 11:14:00	"'/usr/bin/mock' '-r' 'default' '--plugin-option=tmpfs:keep_mounted=True' '--config-opts=print_main_output=True' '--quiet' '--shell' 'tar -c --remove-files '/builddir/cswrap-capture.err'' | tar -xC '/tmp/csmock09j0zm72/units-2.17-5.el8/debug/raw-results'"
tar: Removing leading `/' from member names
csgrep: symbol lookup error: csgrep: undefined symbol: _ZNK5boost15program_options22error_with_option_name23substitute_placeholdersERKSs
csgrep: symbol lookup error: csgrep: undefined symbol: _ZNK5boost15program_options22error_with_option_name23substitute_placeholdersERKSs

!!! 2023-09-25 11:14:01	error: failed to pick cswrap results
```