### PR TITLE
common: present important results by default

### DIFF
--- a/py/common/results.py
+++ b/py/common/results.py
@@ -327,7 +327,8 @@ def finalize_results(js_file, results, props):
         tmp_js_file = re.sub("\\.js", "-tmp.js", js_file)
         cmd = "cslinker --implist '%s' '%s' > '%s' && mv -v '%s' '%s'" \
                 % (imp_js_file, js_file, tmp_js_file, tmp_js_file, js_file)
-        results.exec_cmd(cmd, shell=True)
+        if 0 != results.exec_cmd(cmd, shell=True):
+            results.error("failed to tag important findings in the full results", ec=0)
 
     (err_file, _) = transform_results(js_file, results)
 


### PR DESCRIPTION
... if any filters of important results are defined.

The full results are now available with the `-all` suffix.  The files with `-imp` suffix are provided as symlinks to the filtered results for compatibility.

Resolves: https://issues.redhat.com/browse/OSH-299