### PR TITLE
common: create the compatibility `-imp` symlinks only once

### DIFF
--- a/py/common/results.py
+++ b/py/common/results.py
@@ -362,7 +362,7 @@ def apply_result_filters(props, results, supp_filters=[]):
 
     # create `-imp` symlinks for compatibility (if important defects were filtered)
     if props.imp_checker_set:
-        for suffix in [".err", ".html", "-summary.txt"]:
+        for suffix in [".err", ".html", ".js", "-summary.txt"]:
             src = f"scan-results{suffix}"
             dst = os.path.join(results.resdir, f"scan-results-imp{suffix}")
             results.exec_cmd(["ln", "-s", src, dst])

--- a/py/common/results.py
+++ b/py/common/results.py
@@ -331,12 +331,6 @@ def finalize_results(js_file, results, props):
         # generate *-all{.err,.html,-summary.txt}
         transform_results(all_js_file, results)
 
-        # create `-imp` symlinks for compatibility
-        for suffix in [".err", ".html", "-summary.txt"]:
-            src = f"scan-results{suffix}"
-            dst = os.path.join(results.resdir, f"scan-results-imp{suffix}")
-            results.exec_cmd(["ln", "-s", src, dst])
-
     (err_file, _) = transform_results(js_file, results)
 
     if props.print_defects:
@@ -365,6 +359,13 @@ def apply_result_filters(props, results, supp_filters=[]):
     results.exec_cmd(cmd, shell=True)
     finalize_results(js_supp, results, props)
     finalize_results(js_file, results, props)
+
+    # create `-imp` symlinks for compatibility (if important defects were filtered)
+    if props.imp_checker_set:
+        for suffix in [".err", ".html", "-summary.txt"]:
+            src = f"scan-results{suffix}"
+            dst = os.path.join(results.resdir, f"scan-results-imp{suffix}")
+            results.exec_cmd(["ln", "-s", src, dst])
 
 
 def handle_known_fp_list(props, results):


### PR DESCRIPTION
The code was trying to create them twice by mistake.  The second creation failed, so it was harmless but it unnecessarily polluted `scan.log` like this:
```
[...]
>>> 2023-09-27 18:12:14 "ln" "-s" "scan-results.err" "/tmp/cspodmanfx586tbu/prom-label-proxy-container-v4.1.8-201907241243/scan-results-imp.err"

>>> 2023-09-27 18:12:14 "ln" "-s" "scan-results.html" "/tmp/cspodmanfx586tbu/prom-label-proxy-container-v4.1.8-201907241243/scan-results-imp.html"

>>> 2023-09-27 18:12:14 "ln" "-s" "scan-results-summary.txt" "/tmp/cspodmanfx586tbu/prom-label-proxy-container-v4.1.8-201907241243/scan-results-imp-summary.txt"

>>> 2023-09-27 18:12:14 "csgrep --mode=grep --invert-match --event \"internal warning\" --prune-events=1 '/tmp/cspodmanfx586tbu/prom-label-proxy-container-v4.1.8-201907241243/debug/suppress

>>> 2023-09-27 18:12:14 "csgrep --mode=json --invert-match --event \"internal warning\" --prune-events=1 '/tmp/cspodmanfx586tbu/prom-label-proxy-container-v4.1.8-201907241243/debug/suppress

>>> 2023-09-27 18:12:14 "csgrep --mode=evtstat --invert-match --event \"internal warning\" --prune-events=1 '/tmp/cspodmanfx586tbu/prom-label-proxy-container-v4.1.8-201907241243/debug/suppr

>>> 2023-09-27 18:12:14 "\"bash\" \"-c\" \"csgrep '/tmp/cspodmanfx586tbu/prom-label-proxy-container-v4.1.8-201907241243/scan-results.js' --mode=json --checker '^(RESOURCE_LEAK)\\\$' | csgre

>>> 2023-09-27 18:12:14 "cslinker --implist '/tmp/cspodmanfx586tbu/prom-label-proxy-container-v4.1.8-201907241243/scan-results-imp.js' '/tmp/cspodmanfx586tbu/prom-label-proxy-container-v4.1
renamed '/tmp/cspodmanfx586tbu/prom-label-proxy-container-v4.1.8-201907241243/scan-results-imp.js' -> '/tmp/cspodmanfx586tbu/prom-label-proxy-container-v4.1.8-201907241243/scan-results.js'

>>> 2023-09-27 18:12:14 "csgrep --mode=grep --invert-match --event \"internal warning\" --prune-events=1 '/tmp/cspodmanfx586tbu/prom-label-proxy-container-v4.1.8-201907241243/scan-results-a

>>> 2023-09-27 18:12:14 "csgrep --mode=json --invert-match --event \"internal warning\" --prune-events=1 '/tmp/cspodmanfx586tbu/prom-label-proxy-container-v4.1.8-201907241243/scan-results-a

>>> 2023-09-27 18:12:14 "csgrep --mode=evtstat --invert-match --event \"internal warning\" --prune-events=1 '/tmp/cspodmanfx586tbu/prom-label-proxy-container-v4.1.8-201907241243/scan-result
      2 SUPPRESSED_ERROR                                    suppressed_error

>>> 2023-09-27 18:12:14 "ln" "-s" "scan-results.err" "/tmp/cspodmanfx586tbu/prom-label-proxy-container-v4.1.8-201907241243/scan-results-imp.err"
ln: failed to create symbolic link '/tmp/cspodmanfx586tbu/prom-label-proxy-container-v4.1.8-201907241243/scan-results-imp.err': File exists

>>> 2023-09-27 18:12:14 "ln" "-s" "scan-results.html" "/tmp/cspodmanfx586tbu/prom-label-proxy-container-v4.1.8-201907241243/scan-results-imp.html"
ln: failed to create symbolic link '/tmp/cspodmanfx586tbu/prom-label-proxy-container-v4.1.8-201907241243/scan-results-imp.html': File exists

>>> 2023-09-27 18:12:14 "ln" "-s" "scan-results-summary.txt" "/tmp/cspodmanfx586tbu/prom-label-proxy-container-v4.1.8-201907241243/scan-results-imp-summary.txt"
ln: failed to create symbolic link '/tmp/cspodmanfx586tbu/prom-label-proxy-container-v4.1.8-201907241243/scan-results-imp-summary.txt': File exists
[...]
```

Related: https://issues.redhat.com/browse/OSH-289