### PR TITLE
packaging: add `tar` and `xz` to `Requires`

### DIFF
--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -128,6 +128,8 @@ Requires: csdiff > 3.0.4
 Requires: csgcca
 Requires: cswrap
 Requires: mock
+Requires: tar
+Requires: xz
 %if 0%{?rhel} != 7
 Recommends: modulemd-tools
 %endif


### PR DESCRIPTION
Fixes the following error on minimal OSH worker installations:
```
<<< 2023-10-09 13:27:08	csmock exit code: 0

/bin/sh: line 1: xz: command not found
tar: /tmp/tmpa05fux7j/units-2.21-5.fc37.tar.xz: Wrote only 4096 of 10240 bytes
tar: Child returned status 127
tar: Error is not recoverable: exiting now
!!! 2023-10-09 13:27:08	fatal error: failed to write '/tmp/tmpa05fux7j/units-2.21-5.fc37.tar.xz', not removing '/tmp/csmockbyw9qj7l'...
```