### PR TITLE
csmock-snyk-plugin: no supported projects fix

### DIFF
--- a/py/plugins/snyk.py
+++ b/py/plugins/snyk.py
@@ -170,6 +170,10 @@ class Plugin:
             mock.exec_chroot_cmd("/bin/rm -fv %s" % auth_token_dst)
 
             # check exit code of snyk code itself
+            if ec == 3:
+                # If there are no supported project, we return no results but no crash.
+                results.print_with_ts("snyk-code: no supported projects detected")
+                return 0
             if ec not in [0, 1]:
                 results.error("snyk code returned unexpected exit status: %d" % ec, ec=ec)
 


### PR DESCRIPTION
Fix: https://issues.redhat.com/browse/OSH-329

Reproducer: csmock -r fedora-rawhide-x86_64 -t snyk -o /tmp/tmp_yvvqrnh/attache.tar.xz  --gcc-analyze --unicontrol-notests --unicontrol-bidi-only --shell-cmd=:'/tmp/tmp_yvvqrnh/attache.tar.gz'

Attache needs to be downloaded from: https://github.com/RedHatInsights/attache

If no supported project is detected using the snyk plugin, it no longer crashes but it does return 0.