### PR TITLE
snyk: do not throw away Snyk results by mistake

### DIFF
--- a/py/plugins/snyk.py
+++ b/py/plugins/snyk.py
@@ -187,10 +187,10 @@ class Plugin:
 
         # convert the results into the csdiff's JSON format
         def filter_hook(results):
-            # If no supported project is found, we don't have results file
-            if not os.path.exists(SNYK_OUTPUT):
-                return 0
             src = results.dbgdir_raw + SNYK_OUTPUT
+            if not os.path.exists(src):
+                # do not convert SARIF results if they were not provided by Snyk
+                return 0
             dst = "%s/snyk-capture.js" % results.dbgdir_uni
             cmd = FILTER_CMD % (src, dst)
             return results.exec_cmd(cmd, shell=True)


### PR DESCRIPTION
... on successful scans.  This commit fixes a major regression introduced by the previous commit.

Fixes: commit e8863429bd61fd5308547b084c14f23ac8432c58
Related: https://issues.redhat.com/browse/OSH-329
Resolves: https://issues.redhat.com/browse/OSH-362