### PR TITLE
results: do not treat exit codes above 192 as fatal

### DIFF
--- a/py/common/results.py
+++ b/py/common/results.py
@@ -193,7 +193,7 @@ class ScanResults:
         raise FatalError(ec)
 
     def handle_ec(self):
-        if not self.dying and (128 < self.ec):
+        if not self.dying and (128 < self.ec < (128 + 64)):
             # caught terminating signal, handle synchronous shutdown
             self.fatal_error("caught signal %d" % (self.ec - 128), self.ec)
 


### PR DESCRIPTION
Real-time signals are in the range 32..64 and regular signals below that range.  If an exit code is above `128 + 64 = 192`, it does not denote a terminating signal.

When Snyk code crashes, it returns exit code 255, which should not be handled as termination by a signal:
```
!!! 2023-10-20 13:12:09	fatal error: caught signal 127
```

Related: https://issues.redhat.com/browse/OSH-368