### PR TITLE
csmock: make kfp work for pkgs without the `-release` suffix

### DIFF
--- a/py/csmock
+++ b/py/csmock
@@ -958,8 +958,8 @@ exceeds the specified limit (defaults to 1024).")
         else:
             props.nvr = re.sub("\\.tar$", "", re.sub("\\.[^.]*$", "", srpm_base))
 
-        # cut off version-release to obtain package name
-        props.pkg = re.sub("-[^-]+-[0-9][^-]*$", "", props.nvr)
+        # cut off the -version-release or -version suffix to obtain package name
+        props.pkg = re.sub("-[^-]+(-[0-9][^-]*)?$", "", props.nvr)
 
     # resolve name of the file/dir we are going to store the results to
     if args.output is None:


### PR DESCRIPTION
The code that extracts package name from the `name-version-release` string did not work as expected if the `-release` part was missing. Consequently, it did not find the corresponding `exclude-paths.txt` file in the known-false-positives while scanning a source code tarball named: `RedHatInsights-compliance-backend-bd2b8accb3d4aae88a8c1a71563ec3f5ead7b1fa.tar.gz`

Resolves: https://issues.redhat.com/browse/OSH-392