### PR TITLE
results: reset imp flag in the list of important findings only

### DIFF
--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -124,7 +124,7 @@ Tool for plugging static analyzers into the build process, free of mock.
 
 %package -n csmock-common
 Summary: Core of csmock (a mock wrapper for Static Analysis tools)
-Requires: csdiff > 3.0.4
+Requires: csdiff > 3.1.0
 Requires: csgcca
 Requires: cswrap
 Requires: mock

--- a/py/common/results.py
+++ b/py/common/results.py
@@ -313,7 +313,8 @@ def finalize_results(js_file, results, props):
                     % (js_file, chk_re, csgrep_args)
 
         # finally take all defects that were tagged important by the scanner already
-        cmd += f" | csgrep --mode=json <(csgrep --mode=json --imp-level=1 '{js_file}') -"
+        cmd += " | csgrep --mode=json --set-imp-level=0"
+        cmd += f" <(csgrep --mode=json --imp-level=1 '{js_file}') -"
 
         # write the result into *-imp.js
         imp_js_file = re.sub("\\.js", "-imp.js", js_file)


### PR DESCRIPTION
Tagging important findings does not make sense in the list of important findings only.

Resolves: https://issues.redhat.com/browse/OSH-343
Depends-on: https://github.com/csutils/csdiff/pull/149