### PR TITLE
lint: set `max-line-length=130` for pylint

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,4 @@
+[FORMAT]
+
+# increase threshold to eliminate C0301 warnings about lines exceeding 100 chars
+max-line-length=130

--- a/py/plugins/gitleaks.py
+++ b/py/plugins/gitleaks.py
@@ -132,7 +132,8 @@ class Plugin:
             results.ini_writer.append("analyzer-version-gitleaks", ver)
 
             props.copy_in_files += [gitleaks_bin]
-            cmd = "%s detect --no-git --source=%s --report-path=%s --report-format=sarif" % (gitleaks_bin, GITLEAKS_SCAN_DIR, GITLEAKS_OUTPUT)
+            cmd = f"{gitleaks_bin} detect --no-git cmd --source={GITLEAKS_SCAN_DIR}" \
+                  f" --report-path={GITLEAKS_OUTPUT} --report-format=sarif"
             props.copy_out_files += [GITLEAKS_OUTPUT, GITLEAKS_LOG]
 
             if args.gitleaks_config is not None:

--- a/py/plugins/infer.py
+++ b/py/plugins/infer.py
@@ -121,7 +121,8 @@ class Plugin:
         filter_args_serialized = csmock.common.cflags.serialize_flags(filter_args, separator=" ")
 
         # the filter script tries to filter out false positives and transforms results into csdiff compatible format
-        filter_cmd = f"python3 {INFER_RESULTS_FILTER_SCRIPT} {filter_args_serialized} < {INFER_OUT_DIR}/report.json > {INFER_RESULTS}"
+        filter_cmd = f"python3 {INFER_RESULTS_FILTER_SCRIPT} {filter_args_serialized}" \
+                     f" < {INFER_OUT_DIR}/report.json > {INFER_RESULTS}"
 
         props.copy_out_files += [INFER_RESULTS]
 


### PR DESCRIPTION
Many lines in existing code are longer than 100 chars and attempts to shorten them provoked by pylint usually result in less readable code.