### PR TITLE
csmock: fix insufficient regex escaping in extra_build_repos()

### DIFF
--- a/py/csmock
+++ b/py/csmock
@@ -177,7 +177,7 @@ def extra_build_repos(results, srpm):
     urls = []
 
     # check for a module build
-    m = re.match("^.*/(.*\.module\\+el.*)\\.src\\.rpm$", srpm)
+    m = re.match(r"^.*/(.*\.module\+el.*)\.src\.rpm$", srpm)
     if m:
         nvr = m.group(1)
         repo_url = prepare_module_build_repo(results, nvr)


### PR DESCRIPTION
... to eliminate the following warning on Fedora 39:
```
% csmock -l
/usr/bin/csmock:180: SyntaxWarning: invalid escape sequence '\.'
  m = re.match("^.*/(.*\.module\\+el.*)\\.src\\.rpm$", srpm)
coverity        Proprietary static analyzer providing good signal-to-noise ratio for multiple programming languages.
gcc             Plugin capturing GCC warnings, optionally with customized compiler flags.
```

Reported-by: Lukáš Zaoral
Closes: https://github.com/csutils/csmock/pull/143