### PR TITLE
csmock: make sure that `tar` is installed in chroot

### DIFF
--- a/py/csmock
+++ b/py/csmock
@@ -410,7 +410,7 @@ class ScanProps:
     def __init__(self):
         self.plugins = None
         self.spec_in = None
-        self.install_pkgs = []
+        self.install_pkgs = ["tar"]                     # needed for self.copy_in_files to work
         self.install_pkgs_blacklist = []
         self.install_opt_pkgs = []
         self.add_repos = []


### PR DESCRIPTION
... because it is used by `csmock` itself while copying files into chroot.  This commit fixes the following failure with `--no-scan`:
```
$ csmock -r rhel-8.9.0.z-x86_64 --use-host-cppcheck -o output.tar.xz
[...]
>>> 2023-12-11 10:12:01	"tar -cP '/usr/share/csmock/scripts' '/usr/bin/cswrap' '/usr/lib64/cswrap' '/usr/bin/csclng' '/usr/lib64/csclng' '/usr/bin/csclng++' '/usr/bin/cscppc' '/usr/lib64/cscppc' '/usr/share/cscppc' '/usr/bin/cppcheck' '/usr/share/Cppcheck' '/usr/bin/csgcca' '/usr/lib64/csgcca' '/tmp/csmockvujta3wk/gitleaks' | '/usr/bin/mock' '-r' 'rhel-8.9.0.z-x86_64' '--plugin-option=tmpfs:keep_mounted=True' '--config-opts=print_main_output=True' '--quiet' '--shell' 'tar -xC/'"
/bin/sh: tar: command not found

scan.ini: analyzer-version-clang = 16.0.6
!!! 2023-12-11 10:12:05	error: failed to query cppcheck version
```