### PR TITLE
results: do not duplicate important findings

### DIFF
--- a/py/common/results.py
+++ b/py/common/results.py
@@ -313,7 +313,7 @@ def finalize_results(js_file, results, props):
                     % (js_file, chk_re, csgrep_args)
 
         # finally take all defects that were tagged important by the scanner already
-        cmd += " | csgrep --mode=json --set-imp-level=0"
+        cmd += " | csgrep --mode=json --set-imp-level=0 --remove-duplicates"
         cmd += f" <(csgrep --mode=json --imp-level=1 '{js_file}') -"
 
         # write the result into *-imp.js


### PR DESCRIPTION
... that are tagged important by both a csmock plug-in and the scanner itself.  In a scan of `gcc-toolset-12-gcc-12.2.1-7.4.el9` we had more important findings than all findings, which does not really make any sense:
```
% grep RESOURCE_LEAK gcc-toolset-12-gcc-12.2.1-7.4.el9/scan-results-imp-summary.txt
      2 RESOURCE_LEAK                                           error[too-many]
   2046 RESOURCE_LEAK                                           leaked_storage
    756 RESOURCE_LEAK                                           overwrite_var

% grep RESOURCE_LEAK gcc-toolset-12-gcc-12.2.1-7.4.el9/scan-results-all-summary.txt
      1 RESOURCE_LEAK                                           error[too-many]
   1023 RESOURCE_LEAK                                           leaked_storage
    378 RESOURCE_LEAK                                           overwrite_var
```

Resolves: https://issues.redhat.com/browse/OSH-466