### PR TITLE
results: print `warning` for recoverable errors

### DIFF
--- a/py/common/results.py
+++ b/py/common/results.py
@@ -181,7 +181,8 @@ class ScanResults:
             self.ec = ec
 
     def error(self, msg, ec=1, err_prefix=""):
-        self.print_with_ts("%serror: %s\n" % (err_prefix, msg), prefix="!!! ")
+        level = "warning" if ec == 0 else "error"
+        self.print_with_ts(f"{err_prefix}{level}: {msg}\n", prefix="!!! ")
         self.update_ec(ec)
         if not self.dying and not self.keep_going and (self.ec != 0):
             raise FatalError(ec)


### PR DESCRIPTION
... to make it obvious in `scan.log` that they did not affect the overall exit code.