### PR TITLE
results: skip comments in exclude-paths.txt

### DIFF
--- a/py/common/results.py
+++ b/py/common/results.py
@@ -404,5 +404,8 @@ def handle_known_fp_list(props, results):
         lines = file_handle.readlines()
         for line in lines:
             path_re = line.strip()
+            if len(path_re) == 0 or path_re.startswith("#"):
+                # skip comments and empty lines
+                continue
             filter_cmd = f'csgrep --mode=json --invert-match --path="{shell_quote(path_re)}"'
             props.result_filters += [filter_cmd]


### PR DESCRIPTION
This allows comments in the path exlusion regex file. Instead of adding each line as a filtering rule, it skips empty lines and lines starting with a # symbol.

Fixes https://issues.redhat.com/browse/OSH-508