### PR TITLE
csmock: use the root mock profile property for lock names

### DIFF
--- a/py/csmock
+++ b/py/csmock
@@ -22,6 +22,7 @@ import argparse
 import copy
 import importlib
 import os
+import pathlib
 import pkgutil
 import re
 import shlex
@@ -193,10 +194,6 @@ class MockWrapper:
         self.results = results
         self.mock_profile = props.mock_profile
         self.mock_root_override = props.mock_root_override
-        lock = f"/tmp/.csmock-" + (self.mock_profile if not self.mock_root_override else
-                                   self.mock_root_override).replace('/','_')
-        self.lock_file = f"{lock}.lock"
-        self.meta_lock_file = f"{lock}.metalock"
         self.pid = os.getpid()
         self.scrub_done = props.skip_mock_init
         self.init_done = props.skip_mock_init
@@ -206,6 +203,24 @@ class MockWrapper:
         self.add_repos = props.add_repos
         # just to silence pylint, will be initialized in __enter__()
         self.def_cmd = None
+
+        # get buildroot directory
+        lock_name = self.mock_root = self.mock_root_override
+        if not self.mock_root:
+            cmd = ['mock', '-r', self.mock_profile, '--print-root-path']
+            ec, self.mock_root = results.get_cmd_output(cmd, shell=False)
+            if ec != 0:
+                results.error(f'mock could not determine root path for {self.mock_profile}', ec=ec)
+
+            # strip trailing newline
+            self.mock_root = self.mock_root.strip()
+
+            # use only the basename of the mock root
+            lock_name = pathlib.Path(self.mock_root).parent.stem
+
+        lock = f"/tmp/.csmock-{lock_name.replace('/', '_')}"
+        self.lock_file = f"{lock}.lock"
+        self.meta_lock_file = f"{lock}.metalock"
 
     def __enter__(self):
         cmd = "flock -w%u '%s' -c '\


### PR DESCRIPTION
To fix a crash when two mock profile configuration files have different names but use the same root directory:
```
[...]
>>> 2024-02-19 14:29:12	"/usr/bin/mock" "-r" "/tmp/tmpyfvruenl/mock.cfg" "--plugin-option=tmpfs:keep_mounted=True" "--config-opts=print_main_output=True" "--init"
INFO: mock.py version 5.2 starting (python version = 3.9.18, NVR = mock-5.2-1.kdudka.5.el9), args: /usr/libexec/mock/mock -r /tmp/tmpyfvruenl/mock.cfg --plugin-option=tmpfs:keep_mounted=True --config-opts=print_main_output=True --init
Start(bootstrap): init plugins
INFO: selinux enabled
Finish(bootstrap): init plugins
Start: init plugins
INFO: selinux enabled
Finish: init plugins
INFO: Signal handler active
Start: run
Start: clean chroot
ERROR: Build root is locked by another process.

!!! 2024-02-19 14:29:13	warning: failed to init mock profile (/tmp/tmpyfvruenl/mock.cfg), trying to scrub cache...
[...]
```

Resolves: https://github.com/openscanhub/openscanhub/pull/228#discussion_r1494645666