### PR TITLE
csmock: make kfp work for quarkus-registry.quarkus.redhat.com

### DIFF
--- a/py/csmock
+++ b/py/csmock
@@ -988,7 +988,7 @@ exceeds the specified limit (defaults to 1024).")
             props.nvr = re.sub("\\.tar$", "", re.sub("\\.[^.]*$", "", srpm_base))
 
         # cut off the -version-release or -version suffix to obtain package name
-        props.pkg = re.sub("-[^-]+(-[0-9][^-]*)?$", "", props.nvr)
+        props.pkg = re.sub("-[v]?[0-9][^-]*(-[0-9][^-]*)?$", "", props.nvr)
 
     # resolve name of the file/dir we are going to store the results to
     if args.output is None:


### PR DESCRIPTION
The code that extracts package name from the name-version-release string did not work as expected if the hash suffix started with a digit. Consequently, it did not find the corresponding `exclude-paths.txt` file in the known-false-positives while scanning a source code tarball named: `quarkus-registry.quarkus.redhat.com-01fec5413626d669361dcb0bf921e297be6afdf7.tar.gz`

Related: https://issues.redhat.com/browse/OSH-392
Resolves: https://issues.redhat.com/browse/OSH-623