### PR TITLE
results: set the "imp" flag in the list of important findings

### DIFF
--- a/py/common/results.py
+++ b/py/common/results.py
@@ -314,7 +314,7 @@ def finalize_results(js_file, results, props):
                     % (js_file, chk_re, csgrep_args)
 
         # finally take all defects that were tagged important by the scanner already
-        cmd += " | csgrep --mode=json --set-imp-level=0 --remove-duplicates"
+        cmd += " | csgrep --mode=json --set-imp-level=1 --remove-duplicates"
         cmd += f" <(csgrep --mode=json --imp-level=1 '{js_file}') -"
 
         # write the result into *-imp.js


### PR DESCRIPTION
... rather than clearing it.  If scan results are processed later on, it is useful to know the original state of the "imp" flag, regardless of the context (whether we have a list of important findings only, or an all-in-one list of findings).  A side effect will be that a red `[important]` tag will appear in the HTML output next to each finding, which is probably harmless.

Related: https://issues.redhat.com/browse/OSH-343
Related: https://issues.redhat.com/browse/OSH-565