### PR TITLE
gcc: eliminate misaligned ASCII art coming from GCC analyzer

### DIFF
--- a/py/plugins/gcc.py
+++ b/py/plugins/gcc.py
@@ -261,6 +261,11 @@ class Plugin:
                                   "disabling the tool" % analyzer_bin, ec=0)
                     return 0
 
+                # use -fdiagnostics-text-art-charset=none if supported by gcc in the chroot
+                flag = "-fdiagnostics-text-art-charset=none"
+                if 0 == mock.exec_mockbuild_cmd(f"{cmd} {flag}"):
+                    props.env["CSGCCA_ADD_OPTS"] = flag
+
                 if args.gcc_analyzer_bin:
                     # create an executable shell script to wrap the custom gcc binary
                     wrapper_script = CSMOCK_GCC_WRAPPER_TEMPLATE % analyzer_bin


### PR DESCRIPTION
New versions of GCC started to produce ASCII art, which is not properly handled by the plain-text parser in csdiff:
```
 Error: GCC_ANALYZER_WARNING (CWE-126): [#def1]
 bluez-5.75/emulator/bthost.c: scope_hint: In function ‘queue_command’
 bluez-5.75/emulator/bthost.c:571:52: warning[-Wanalyzer-out-of-bounds]: stack-based buffer over-read
 bluez-5.75/emulator/bthost.c:571:52: note: read of 8 bytes from after the end of ‘iov’
 bluez-5.75/emulator/bthost.c:571:52: note: valid subscripts for ‘iov’ are ‘[0]’ to ‘[2]’
 #                                              └──────────────────────────┘
 #                                                           ^
 #  569|
 #  570|   	for (i = 0; i < iovlen; i++) {
 #  571|-> 		memcpy(cmd->data + cmd->len, iov[i].iov_base, iov[i].iov_len);
 #  572|   		cmd->len += iov[i].iov_len;
 #  573|   	}
```

If gcc in the chroot recognizes `-fdiagnostics-text-art-charset=none`, use it to prevent GCC analyzer from producing such output.

Reported-by: David Malcolm