### PR TITLE
csmock: fix Permission denied errors on /builddir

### DIFF
--- a/py/csmock
+++ b/py/csmock
@@ -1124,6 +1124,9 @@ the package.  Use --tools or --all-tools to enable them!\n", ec=0)
                     # just to update rpm-list-mock.txt
                     find_missing_pkgs([], results, mock)
 
+                # make /builddir writable without root access
+                mock.exec_chroot_cmd("chown mockbuild -R /builddir")
+
                 if supermin_in_use:
                     # attempt to make name resolving work in the chroot
                     mock.copy_in_resolv_conf()


### PR DESCRIPTION
... while scaning tarballs instead of SRPMs:
```
$ csmock -r fedora-rawhide-x86_64 -t clippy --shell-cmd='cargo build' -f trustification-main.tar.gz
[...]
+ cargo build
+ set -- clippy
+ /usr/bin/cargo_original clippy --message-format=json
/usr/bin/cargo: line 9: /builddir/clippy-output.txt: Permission denied
+ /usr/bin/cargo_original build
    Updating git repository `https://github.com/ctron/csaf-rs`
error: failed to load source for dependency `csaf`

Caused by:
  Unable to update https://github.com/ctron/csaf-rs?rev=183326beac525d58962f78be8eca973017702753#183326be

Caused by:
  failed to create directory `/builddir/.cargo/git/db/csaf-rs-27cd9c29798421c8`

Caused by:
  Permission denied (os error 13)
Finish: chroot ['/bin/su mockbuild -l -c "PATH=\\$PATH sh -c \\"sh -x \'/tmp/csmockgr5cszf3/build.sh\'\\""']
Finish: run

!!! 2024-04-23 16:13:23	error: %build failed
```

Reported-by: Jonathan Christison