### PR TITLE
chroot-fixups: make our scripts work again in pre-UsrMove chroots

### DIFF
--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -301,7 +301,7 @@ This package contains the unicontrol plug-in for csmock.
 %{_mandir}/man1/csmock.1*
 %{_datadir}/csmock/cwe-map.csv
 %{_datadir}/csmock/scripts/enable-keep-going.sh
-%{_datadir}/csmock/scripts/chroot-fixups
+%attr(755,root,root) %{_datadir}/csmock/scripts/chroot-fixups
 %{_datadir}/csmock/scripts/patch-rawbuild.sh
 %{python3_sitelib}/csmock/__init__.py*
 %{python3_sitelib}/csmock/common

--- a/scripts/chroot-fixups/00-pre-usr-move-shells.sh
+++ b/scripts/chroot-fixups/00-pre-usr-move-shells.sh
@@ -1,0 +1,14 @@
+# intentionally no shebang so that rpmbuild does not break this script
+# shellcheck shell=sh
+
+# exit successfully if this is a post-UsrMove chroot
+test -L /bin && exit 0
+
+# if rpmbuild from the host env translated /bin/bash to /usr/bin/bash in the
+# shebangs of our scripts, create reverse symlinks to make the scripts work
+# in the chroot env again
+for sh in bash sh; do
+    dst=/usr/bin/${sh}
+    test -e ${dst} && continue
+    test -x /bin/${sh} && ln -sv ../../bin/${sh} $dst
+done


### PR DESCRIPTION
When we build csmock for RHEL-9, rpmbuild translates `/bin/bash` to `/usr/bin/bash` in our scripts.  When we copy the scripts into an old chroot, such as `rhel-6-x86_64`, the translated path does not exist and the script fails with:
```
>>> 2024-05-20 12:04:36	"/usr/bin/mock" "-r" "rhel-6-x86_64" "--plugin-option=tmpfs:keep_mounted=True" "--config-opts=print_main_output=True" "--quiet" "--chroot" "/usr/share/csmock/scripts/run-shellcheck.sh /builddir/build/BUILDROOT > /builddir/shellcheck-capture.err"
/bin/sh: /usr/share/csmock/scripts/run-shellcheck.sh: /usr/bin/bash: bad interpreter: No such file or directory
```