### PR TITLE
clippy: do not fail scan of packages without Rust code

### DIFF
--- a/py/plugins/clippy.py
+++ b/py/plugins/clippy.py
@@ -1,3 +1,5 @@
+import os
+
 import csmock.common.util
 
 RUN_CLIPPY_CONVERT = "/usr/share/csmock/scripts/convert-clippy.py"
@@ -37,6 +39,10 @@ class Plugin:
 
         def convert_hook(results):
             src = f"{results.dbgdir_raw}{CLIPPY_OUTPUT}"
+            if not os.path.exists(src):
+                # if `cargo build` was not executed during the scan, there are no results to process
+                return 0
+
             dst = f"{results.dbgdir_uni}/clippy-capture.err"
             cmd = f'set -o pipefail; {RUN_CLIPPY_CONVERT} < {src} | csgrep --remove-duplicates > {dst}'
             return results.exec_cmd(cmd, shell=True)


### PR DESCRIPTION
We want to enable `clippy` in the default scanning profile in a way that it takes an effect for packages that build Rust code.  For packages that do not build any Rust code, the plug-in should do nothing rather than failing the whole scan:
```
% csmock -at clippy -r rhel-7-x86_64 -f units-2.01-5.el7_9.src.rpm
[...]
>>> 2024-05-28 12:24:21 "set -o pipefail; /usr/share/csmock/scripts/convert-clippy.py < /tmp/csmocknsbuwvil/units-2.01-5.el7_9/debug/raw-results/builddir/clippy-output.txt | csgrep --remove-duplicates > /tmp/csmocknsbuwvil/units-2.01-5.el7_9/debug/uni-results/clippy-capture.err"
/bin/sh: line 1: /tmp/csmocknsbuwvil/units-2.01-5.el7_9/debug/raw-results/builddir/clippy-output.txt: No such file or directory

!!! 2024-05-28 12:24:21 error: post-process hook failed
```

Fixes: commit d21690381046f9a176e5fb36672f5f7105e419fc
Related: https://issues.redhat.com/browse/OSH-30