### PR TITLE
clippy: make the cargo wrapper work in bash

### DIFF
--- a/scripts/inject-clippy.sh
+++ b/scripts/inject-clippy.sh
@@ -15,11 +15,11 @@ sed "s|REPLACE_ME|$NEW_LOCATION|g" > $ORIGINAL_LOCATION << 'EOF'
 #!/bin/bash
 
 # look for "build" in command-line args
-for ((i=0; i<$#; i++)); do
-    if [[ "${@[i]}" == "build" ]]; then
+for ((i=1; i<$#; i++)); do
+    if [[ "${!i}" == "build" ]]; then
         # found! --> execute the command with "build" substituted by "clippy"
         set -x
-        REPLACE_ME "${@::i}" clippy "${@:i+1}" --message-format=json >> /builddir/clippy-output.txt
+        REPLACE_ME "${@:1:i-1}" clippy "${@:i+1}" --message-format=json >> /builddir/clippy-output.txt
         break
     fi
 done


### PR DESCRIPTION
It turned out that the last change was not properly tested.
The previously used syntax is not recognized by bash:
```
[...]
cd ./librsvg && \
PKG_CONFIG_ALLOW_CROSS=1 \
PKG_CONFIG='/usr/bin/pkg-config' \
CARGO_TARGET_DIR=/builddir/build/BUILD/librsvg-2.50.7/target \
cargo --locked build --verbose  --release \
&& cd /builddir/build/BUILD/librsvg-2.50.7 && /bin/sh ./libtool  --tag=CC   --mode=link gcc  -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=forma
/usr/bin/cargo: line 5: ${@[i]}: bad substitution
[...]
```

This commit fixes it.  Moreover, the invocation of `cargo_original` was
wrong because the wrapper path was passed as the first command-line arg
by mistake:
```
[...]
cd ./librsvg &&                     \
PKG_CONFIG_ALLOW_CROSS=1                        \
PKG_CONFIG='/usr/bin/x86_64-redhat-linux-gnu-pkg-config'                        \
CARGO_TARGET_DIR=/builddir/build/BUILD/librsvg-2.50.7/target                    \
cargo --locked build --verbose  --release \
&& cd /builddir/build/BUILD/librsvg-2.50.7 && /bin/sh ./libtool  --tag=CC   --mode=link gcc  -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=forma
+ /usr/bin/cargo_original /usr/bin/cargo --locked clippy --verbose --release --message-format=json
error: running `/usr/bin/cargo` requires `-Zscript`
+ break
+ exec /usr/bin/cargo_original --locked build --verbose --release
[...]
```

Related: https://issues.redhat.com/browse/OSH-30