### PR TITLE
csmock: use `Path.name` to get the basename

### DIFF
--- a/py/csmock
+++ b/py/csmock
@@ -216,7 +216,7 @@ class MockWrapper:
             self.mock_root = self.mock_root.strip()
 
             # use only the basename of the mock root
-            lock_name = pathlib.Path(self.mock_root).parent.stem
+            lock_name = pathlib.Path(self.mock_root).parent.name
 
         lock = f"/tmp/.csmock-{lock_name.replace('/', '_')}"
         self.lock_file = f"{lock}.lock"


### PR DESCRIPTION
... and not `Path.stem` which also removes a filename suffix.

Fixes: b2c720159d52ac89e10e290237f230dbe41848a8 ("csmock: use the root mock profile property for lock names")
Resolves: https://issues.redhat.com/browse/OSH-464