### PR TITLE
csmock: use `NOCHECK_RPM_OPTS` also for `%build`

### DIFF
--- a/py/csmock
+++ b/py/csmock
@@ -1200,8 +1200,11 @@ cd %%s*/ || cd *\n\
                     if not props.skip_build:
                         if props.shell_cmd_to_build is None:
                             # run %build phase with static analyzers plugged-in
+                            rpm_opts = props.rpm_opts
+                            if not props.run_check:
+                                rpm_opts += NOCHECK_RPM_OPTS
                             build_cmd = "rpmbuild -bc --nodeps --short-circuit %s %s" \
-                                    % (props.spec_in, strlist_to_shell_cmd(props.rpm_opts))
+                                    % (props.spec_in, strlist_to_shell_cmd(rpm_opts))
                         else:
                             # run the above prepared build script
                             build_cmd = "sh -x '%s'" % build_script


### PR DESCRIPTION
... when execution of tests is not needed for the requested scan. This fixes an unnecessary failure while SAST scanning `jss-4.9.4-1.module+el8.7.0+15532+95bac9ee`

Resolves: https://issues.redhat.com/browse/OSH-697
Closes: https://github.com/csutils/csmock/pull/176