### PR TITLE
cwe-map.csv: fix a misplaced quote

### DIFF
--- a/cwe-map.csv
+++ b/cwe-map.csv
@@ -312,7 +312,7 @@
 "GCC_ANALYZER_WARNING","warning[-Wanalyzer-fd-use-after-close]","CWE-910"
 "GCC_ANALYZER_WARNING","warning[-Wanalyzer-file-leak]","CWE-775"
 "GCC_ANALYZER_WARNING","warning[-Wanalyzer-free-of-non-heap]","CWE-590"
-"GCC_ANALYZER_WARNING","warning[-Wanalyzer-infinite-recursion]","CWE-"674
+"GCC_ANALYZER_WARNING","warning[-Wanalyzer-infinite-recursion]","CWE-674"
 "GCC_ANALYZER_WARNING","warning[-Wanalyzer-jump-through-null]","CWE-476"
 "GCC_ANALYZER_WARNING","warning[-Wanalyzer-malloc-leak]","CWE-401"
 "GCC_ANALYZER_WARNING","warning[-Wanalyzer-mismatching-deallocation]","CWE-762"


### PR DESCRIPTION
... that causes a parsing error and prevents GitHub from rendering the page properly.

Fixes: commit c4cecc307723f0bf925c88dcd51ae3a311ff784f