### PR TITLE
ci: disable EPEL-7 tests

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -38,16 +38,6 @@ jobs:
     - job: tests
       trigger: pull_request
       targets:
-          - epel-7-x86_64
-      identifier: epel7
-      tf_extra_params:
-          environments:
-              - artifacts:
-                  - type: repository-file
-                    id: https://copr.fedorainfracloud.org/coprs/g/codescan/csutils/repo/epel-7/group_codescan-csutils-epel-7
-    - job: tests
-      trigger: pull_request
-      targets:
           - epel-8-aarch64
           - epel-8-x86_64
       identifier: epel8


### PR DESCRIPTION
They started to fail because EPEL-7 is EOL:
```
[08:31:04] [E] [worker_0] [artemis] [597190e3-c5dc-4b67-9ea7-6803ab0302cf] [pre-artifact-installation] Last 30 lines of Ansible stdout:
---v---v---v---v---v---
    "skip_reason": "Conditional result was False"
}

TASK [Enable Powertools repository (CentOS 8, CentOS Stream 8)] ****************
skipping: [3.136.112.131] => {
    "changed": false,
    "skip_reason": "Conditional result was False"
}

TASK [include_tasks] ***********************************************************
included: /CONFIG/guest-setup/pre-artifact-installation/install-epel.yaml for 3.136.112.131

TASK [Install EPEL on CentOS < 9 and CentOS Stream < 9 (except CentOS Stream 9)] ***
FAILED - RETRYING: [3.136.112.131]: Install EPEL on CentOS < 9 and CentOS Stream < 9 (except CentOS Stream 9) (5 retries left).
FAILED - RETRYING: [3.136.112.131]: Install EPEL on CentOS < 9 and CentOS Stream < 9 (except CentOS Stream 9) (4 retries left).
FAILED - RETRYING: [3.136.112.131]: Install EPEL on CentOS < 9 and CentOS Stream < 9 (except CentOS Stream 9) (3 retries left).
FAILED - RETRYING: [3.136.112.131]: Install EPEL on CentOS < 9 and CentOS Stream < 9 (except CentOS Stream 9) (2 retries left).
FAILED - RETRYING: [3.136.112.131]: Install EPEL on CentOS < 9 and CentOS Stream < 9 (except CentOS Stream 9) (1 retries left).
fatal: [3.136.112.131]: FAILED! => {
    "attempts": 5,
    "changed": false
}

MSG:

Failure talking to yum: Cannot find a valid baseurl for repo: base/7/x86_64

PLAY RECAP *********************************************************************
3.136.112.131              : ok=15   changed=2    unreachable=0    failed=1    skipped=22   rescued=0    ignored=3

---^---^---^---^---^---
[08:31:04] [E] [CentOS-7:x86_64:/plans/ci] guest setup failed: Failure during Ansible playbook execution
```