### PR TITLE
chroot-fixups: prevent `%install` of llvm from taking ages to complete

### DIFF
--- a/scripts/chroot-fixups/rpm-build-scripts.sh
+++ b/scripts/chroot-fixups/rpm-build-scripts.sh
@@ -1,11 +1,13 @@
-#!/bin/sh
+#!/bin/bash
 
 script="/usr/lib/rpm/redhat/brp-mangle-shebangs"
 if [ -x $script ]; then
     (set -x; sed -e 's/fail=1/fail=0/' -i $script )
 fi
 
-script="/usr/lib/rpm/brp-strip-static-archive"
-if [ -f $script ]; then
-    ln -sfvT /bin/true $script
-fi
+# skip RPM scripts running in %install that are not needed and break scans
+for script in /usr/lib/rpm/{redhat/brp-llvm-compile-lto-elf,brp-strip-static-archive}; do
+    if [ -f "$script" ]; then
+        ln -fsvT /bin/true "$script"
+    fi
+done


### PR DESCRIPTION
The `brp-llvm-compile-lto-elf` script does not work well in our scanning environment and causes the %install section of `llvm-16.0.6-4.el9` to take 7 days to complete.

Depends-on: https://github.com/csutils/csmock/pull/179