### PR TITLE
cppcheck: suppress information[normalCheckLevelMaxBranches] reports

### DIFF
--- a/py/plugins/cppcheck.py
+++ b/py/plugins/cppcheck.py
@@ -65,7 +65,7 @@ class Plugin:
         props.env["CSWRAP_TIMEOUT_FOR"] += ":cppcheck"
         props.cswrap_filters += ["csgrep --mode=json --invert-match \
 --checker CPPCHECK_WARNING \
---event 'cppcheckError|internalAstError|preprocessorErrorDirective|syntaxError|unknownMacro'"]
+--event 'cppcheckError|internalAstError|normalCheckLevelMaxBranches|preprocessorErrorDirective|syntaxError|unknownMacro'"]
 
         if args.cppcheck_add_flag:
             # propagate custom cppcheck flags


### PR DESCRIPTION
```
Error: CPPCHECK_WARNING: [#def1]
units-2.22/getopt.c: information[normalCheckLevelMaxBranches]: Limiting analysis of branches. Use --check-level=exhaustive to analyze all branches.

Error: CPPCHECK_WARNING: [#def2]
units-2.22/parse.tab.c: information[normalCheckLevelMaxBranches]: Limiting analysis of branches. Use --check-level=exhaustive to analyze all branches.
```