### PR TITLE
shellcheck: use a new version of `run-shellcheck.sh`

### DIFF
--- a/py/csmock
+++ b/py/csmock
@@ -1226,7 +1226,7 @@ cd %%s*/ || cd *\n\
                             if mock.exec_chroot_cmd("rpmbuild --nocheck") == 0:
                                 extra_rpm_opts += ["--nocheck"]
                             else:
-                                # fragile compatiblity workaround for older versions of rpm-build,
+                                # fragile compatibility workaround for older versions of rpm-build,
                                 # known to break if unescaped %check appears in a change log entry
                                 extra_rpm_opts += ["--define", "check\\\n%%check\\\nexit 0"]
 
@@ -1247,7 +1247,9 @@ cd %%s*/ || cd *\n\
 
                         # execute post-build commands in the chroot
                         for cmd in props.post_build_chroot_cmds:
-                            mock.exec_chroot_cmd(cmd)
+                            rv = mock.exec_chroot_cmd(cmd)
+                            if rv != 0:
+                                results.error(f"post-build-chroot command failed with exit code: {rv}", ec=0)
 
                     finally:
                         # get the (intermediate) results out of the chroot

--- a/py/plugins/shellcheck.py
+++ b/py/plugins/shellcheck.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with csmock.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
+
 import csmock.common.util
 
 
@@ -22,8 +24,8 @@ RUN_SHELLCHECK_SH = "/usr/share/csmock/scripts/run-shellcheck.sh"
 
 SHELLCHECK_CAPTURE = "/builddir/shellcheck-capture.err"
 
-FILTER_CMD = "csgrep --quiet '%s' " \
-        "| csgrep --invert-match --event '^note|warning\\[SC1090\\]' " \
+FILTER_CMD = "csgrep --mode=json --remove-duplicates --quiet '%s' " \
+        "--invert-match --event '^note|warning\\[SC1090\\]' " \
         "> '%s'"
 
 
@@ -64,8 +66,8 @@ class Plugin:
         csmock.common.util.install_default_toolver_hook(props, "ShellCheck")
 
         def filter_hook(results):
-            src = results.dbgdir_raw + SHELLCHECK_CAPTURE
-            dst = "%s/shellcheck-capture.err" % results.dbgdir_uni
+            src = os.path.join(results.dbgdir_raw, SHELLCHECK_CAPTURE[1:])
+            dst = os.path.join(results.dbgdir_uni, "shellcheck-capture.json")
             cmd = FILTER_CMD % (src, dst)
             return results.exec_cmd(cmd, shell=True)
 

--- a/py/plugins/shellcheck.py
+++ b/py/plugins/shellcheck.py
@@ -27,6 +27,9 @@ SHELLCHECK_CAP_DIR = "/builddir/shellcheck-results"
 FILTER_CMD = "csgrep --mode=json --remove-duplicates --quiet " \
         "--invert-match --event '^note|warning\\[SC1090\\]'"
 
+# default maximum number of scripts scanned by a single shellcheck process
+DEFAULT_SC_BATCH = 1
+
 # default maximum amount of wall-clock time taken by a single shellcheck process [s]
 DEFAULT_SC_TIMEOUT = 30
 
@@ -52,6 +55,10 @@ class Plugin:
     def init_parser(self, parser):
         csmock.common.util.install_script_scan_opts(parser, "shellcheck")
         parser.add_argument(
+            "--shellcheck-batch", type=int, default=DEFAULT_SC_BATCH,
+            help="maximum number of scripts scanned by a single shellcheck process" \
+                f" (defaults to {DEFAULT_SC_BATCH})")
+        parser.add_argument(
             "--shellcheck-timeout", type=int, default=DEFAULT_SC_TIMEOUT,
             help="maximum amount of wall-clock time taken by a single shellcheck process [s]" \
                 f" (defaults to {DEFAULT_SC_TIMEOUT})")
@@ -69,6 +76,7 @@ class Plugin:
 
         props.install_pkgs += ["ShellCheck"]
         cmd = f"SC_RESULTS_DIR={SHELLCHECK_CAP_DIR} "
+        cmd += f"SC_BATCH={args.shellcheck_batch} "
         cmd += f"SC_TIMEOUT={args.shellcheck_timeout} "
         cmd += f"{RUN_SHELLCHECK_SH} {dirs_to_scan}"
         props.post_build_chroot_cmds += [cmd]

--- a/py/plugins/shellcheck.py
+++ b/py/plugins/shellcheck.py
@@ -25,7 +25,7 @@ RUN_SHELLCHECK_SH = "/usr/share/csmock/scripts/run-shellcheck.sh"
 SHELLCHECK_CAP_DIR = "/builddir/shellcheck-results"
 
 FILTER_CMD = "csgrep --mode=json --remove-duplicates --quiet " \
-        "--invert-match --event '^note|warning\\[SC1090\\]'"
+        "--invert-match --event '^info|style|warning\\[SC1090\\]'"
 
 # default maximum number of scripts scanned by a single shellcheck process
 DEFAULT_SC_BATCH = 1

--- a/py/plugins/shellcheck.py
+++ b/py/plugins/shellcheck.py
@@ -57,6 +57,9 @@ class Plugin:
         dirs_to_scan = csmock.common.util.dirs_to_scan_by_args(
             parser, args, props, "shellcheck")
 
+        # append "/*" to each directory in dirs_to_scan (to scan pkg-specific dirs)
+        dirs_to_scan = " ".join([dir + "/*" for dir in dirs_to_scan.split()])
+
         props.install_pkgs += ["ShellCheck"]
         cmd = f"SC_RESULTS_DIR={SHELLCHECK_CAP_DIR} {RUN_SHELLCHECK_SH} {dirs_to_scan}"
         props.post_build_chroot_cmds += [cmd]

--- a/scripts/run-shellcheck.sh
+++ b/scripts/run-shellcheck.sh
@@ -36,6 +36,22 @@ if shellcheck --help 2>/dev/null | grep -q external-sources; then
     SC_OPTS+=(--external-sources)
 fi
 
+# check whether shellcheck supports --source-path
+if shellcheck --help 2>/dev/null | grep -q source-path; then
+    sp=
+    for dir in "$@"; do
+        # search path works only for directories
+        test -d "$dir" || continue
+
+        # append a single directory from cmd-line args of this script
+        sp="${sp}:${dir}"
+    done
+    if test -n "$sp"; then
+        # pass the colon-delimited list of dirs via --source-path to shellcheck
+        SC_OPTS+=(--source-path="${sp#:}")
+    fi
+fi
+
 # implementation of the script that filters shell scripts
 filter_shell_scripts() {
     for i in "$@"; do

--- a/scripts/run-shellcheck.sh
+++ b/scripts/run-shellcheck.sh
@@ -31,6 +31,11 @@ else
     SC_RESULTS_END='}'
 fi
 
+# check whether shellcheck supports --external-sources
+if shellcheck --help 2>/dev/null | grep -q external-sources; then
+    SC_OPTS+=(--external-sources)
+fi
+
 # implementation of the script that filters shell scripts
 filter_shell_scripts() {
     for i in "$@"; do

--- a/scripts/run-shellcheck.sh
+++ b/scripts/run-shellcheck.sh
@@ -2,7 +2,8 @@
 export LC_ALL="C"
 
 # how many shell scripts we pass to shellcheck at a time
-export SC_BATCH=1
+test -n "$SC_BATCH" || export SC_BATCH=1
+test 0 -lt "$SC_BATCH" || exit $?
 
 # how many shellcheck processes we run in parallel
 SC_JOBS=$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1)

--- a/scripts/run-shellcheck.sh
+++ b/scripts/run-shellcheck.sh
@@ -9,7 +9,8 @@ SC_JOBS=$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1)
 export SC_JOBS
 
 # how long we wait (wall-clock time) for a single shellcheck process to finish
-export SC_TIMEOUT=30
+test -n "$SC_TIMEOUT" || export SC_TIMEOUT=30
+test 0 -lt "$SC_TIMEOUT" || exit $?
 
 # directory for shellcheck results
 test -n "$SC_RESULTS_DIR" || export SC_RESULTS_DIR="./shellcheck-results"

--- a/scripts/run-shellcheck.sh
+++ b/scripts/run-shellcheck.sh
@@ -1,19 +1,38 @@
 #!/bin/bash
 export LC_ALL="C"
 
+# how many shell scripts we pass to shellcheck at a time
+export SC_BATCH=1
+
+# how many shellcheck processes we run in parallel
+SC_JOBS=$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1)
+export SC_JOBS
+
+# how long we wait (wall-clock time) for a single shellcheck process to finish
+export SC_TIMEOUT=30
+
+# directory for shellcheck results
+test -n "$SC_RESULTS_DIR" || export SC_RESULTS_DIR="./shellcheck-results"
+
+# create the directory for shellcheck results and check we can write to it
+mkdir "${SC_RESULTS_DIR}" || exit $?
+touch "${SC_RESULTS_DIR}/empty.json" || exit $?
+
 # implementation of the script that filters shell scripts
 filter_shell_scripts() {
     for i in "$@"; do
         # match by file name suffix
         if [[ "$i" =~ ^.*\.(ash|bash|bats|dash|ksh|sh)$ ]]; then
-            readlink -f "$i"
+            echo "$i"
+            echo -n . >&2
             continue
         fi
 
-        # match by shebang
+        # match by shebang (executable files only)
         RE_SHEBANG='^\s*((#|!)|(#\s*!)|(!\s*#))\s*(/usr(/local)?)?/bin/(env\s+)?(ash|bash|bats|dash|ksh|sh)\b'
-        if head -n1 "$i" | grep --text -E "$RE_SHEBANG" >/dev/null; then
-            readlink -f "$i"
+        if test -x "$i" && head -n1 "$i" | grep -qE --text "$RE_SHEBANG"; then
+            echo "$i"
+            echo -n . >&2
         fi
     done
 }
@@ -22,11 +41,37 @@ filter_shell_scripts() {
 FILTER_SCRIPT="$(declare -f filter_shell_scripts)
 filter_shell_scripts"' "$@"'
 
+# function that creates a separate JSON file if shellcheck detects anything
+wrap_shellcheck() {
+    dst="${SC_RESULTS_DIR}/sc-$$.json"
+    (set -x && timeout "${SC_TIMEOUT}" shellcheck --format=json1 "$@" > "$dst")
+    EC=$?
+    case $EC in
+        0)
+            # no findings detected -> remove the output file
+            rm -f "$dst"
+            ;;
+
+        1)
+            # findings detected -> successful run
+            return 0
+            ;;
+
+        *)
+            # propagate other errors
+            return $EC
+            ;;
+    esac
+}
+
+# store a script that filters shell scripts to a variable
+SC_WRAP_SCRIPT="$(declare -f wrap_shellcheck)
+wrap_shellcheck"' "$@"'
+
+# find all shell scripts and run shellcheck on them
+echo -n "Looking for shell scripts..." >&2
 find "$@" -type f -print0 \
     | xargs -0 /bin/bash -c "$FILTER_SCRIPT" "$0" \
-    | grep -v '^/builddir/build/BUILDROOT/[^/]\+/usr/share/dirsrv/script-templates/' \
-    | grep -Ev '^/builddir/build/BUILDROOT/[^/]+/usr/share/systemtap/(examples|testsuite)/' \
-    | sort -V | tee /dev/fd/2 \
-    | xargs -r shellcheck --format=gcc \
-    | sed 's/$/ <--[shellcheck]/' \
-    | tee /dev/fd/2
+    | { sort -uV && echo " done" >&2; } \
+    | xargs -rn "${SC_BATCH}" --max-procs="${SC_JOBS}" \
+    /bin/bash -c "$SC_WRAP_SCRIPT" "$0"

--- a/tests/simple_build/shellcheck.fmf
+++ b/tests/simple_build/shellcheck.fmf
@@ -1,0 +1,11 @@
+summary: Test analysis using ShellCheck
+test: ./test.sh
+framework: beakerlib
+environment:
+      TEST_PACKAGE: dracut
+      TEST_TOOL: shellcheck
+component:
+  - csmock
+recommend:
+  - csmock
+duration: 1h

--- a/tests/simple_build/test.sh
+++ b/tests/simple_build/test.sh
@@ -7,6 +7,10 @@ TEST_PACKAGE="${TEST_PACKAGE:-}"
 TEST_TOOL="${TEST_TOOL:-}"
 TEST_USER="csmock"
 
+# Add CS Koji
+BEAKERLIB_rpm_fetch_base_url+=( "https://kojihub.stream.centos.org/kojifiles/packages/" )
+BEAKERLIB_rpm_packageinfo_base_url+=( "https://kojihub.stream.centos.org/koji/" )
+
 rlJournalStart
     rlPhaseStartSetup
         # use the latest csutils in the Testing Farm


### PR DESCRIPTION
... initially developed for Konflux CI.  The updated version runs more processes of `shellcheck` in parallel, each of them with a strictly set timeout (by default 30s of wall-clock time).

Related: https://issues.redhat.com/browse/OSH-655
Resolves: https://issues.redhat.com/browse/OSH-733
