### PR TITLE
gcc: use SARIF output with `--gcc-analyzer-bin`

### DIFF
--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -125,7 +125,7 @@ Tool for plugging static analyzers into the build process, free of mock.
 
 %package common
 Summary: Core of csmock (a mock wrapper for Static Analysis tools)
-Requires: csdiff > 3.1.0
+Requires: csdiff > 3.5.1
 Requires: csgcca
 Requires: cswrap
 Requires: mock >= 5.7


### PR DESCRIPTION
With https://copr.fedorainfracloud.org/coprs/dmalcolm/gcc-latest/ added to the `fedora-41-x86_64` mock config, this can be tested using the following commands:
```
koji download-build -a src units-2.23-3.fc41
csmock -f units-2.23-3.fc41.src.rpm -r fedora-41-x86_64 --install gcc-latest --gcc-analyzer-bin /opt/gcc-latest/bin/gcc
```

Depends-on: https://github.com/csutils/csdiff/pull/210
Related: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=116613