### PR TITLE
install dynamic build dependencies, too

### DIFF
--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -128,7 +128,7 @@ Summary: Core of csmock (a mock wrapper for Static Analysis tools)
 Requires: csdiff > 3.1.0
 Requires: csgcca
 Requires: cswrap
-Requires: mock
+Requires: mock >= 5.7
 Requires: tar
 Requires: xz
 %if 0%{?rhel} != 7

--- a/py/common/results.py
+++ b/py/common/results.py
@@ -180,7 +180,14 @@ class ScanResults:
         if self.ec < ec:
             self.ec = ec
 
-    def error(self, msg, ec=1, err_prefix=""):
+    def error(self, msg, ec=1, err_prefix="", fatal=False):
+        if fatal:
+            assert not err_prefix
+
+            # cannot recurse, should never return
+            self.fatal_error(msg, ec)
+            assert False
+
         level = "warning" if ec == 0 else "error"
         self.print_with_ts(f"{err_prefix}{level}: {msg}\n", prefix="!!! ")
         self.update_ec(ec)

--- a/py/csmock
+++ b/py/csmock
@@ -354,11 +354,16 @@ echo \"$self_pid\" > \"$lock_file\"'" \
         cmd = ["--installdeps", srpm] + cmd_add
         return (self.exec_mock_cmd(cmd, quiet=quiet) == 0)
 
-    def emergency_install_deps(self, srpm):
-        (_, raw_deps) = self.results.get_cmd_output("rpm -qp '%s' --requires" % srpm)
-        for dep in raw_deps.split("\n"):
+    def emergency_install_pkgs(self, pkgs):
+        """try to install pkgs one by one"""
+        for dep in pkgs:
             if (dep):
                 self.try_install([dep])
+
+    def emergency_install_deps(self, srpm):
+        (_, raw_deps) = self.results.get_cmd_output("rpm -qp '%s' --requires" % srpm)
+        pkgs = raw_deps.split("\n")
+        self.emergency_install_pkgs(pkgs)
 
     def remove(self, pkgs):
         return (self.exec_mock_cmd(["--remove"] + pkgs) == 0)
@@ -403,6 +408,11 @@ echo \"$self_pid\" > \"$lock_file\"'" \
                 return srpm_deps_ok
             if try_only:
                 return False
+
+            if keep_going:
+                # try to install the missing packages one by one
+                self.emergency_install_pkgs(missing_deps)
+                missing_deps = find_missing_pkgs(pkgs, self.results, self)
 
             self.results.error(f"failed to install required packages ({strlist_to_shell_cmd(missing_deps)})",
                                ec=ec_by_scrub)

--- a/py/csmock
+++ b/py/csmock
@@ -363,15 +363,8 @@ echo \"$self_pid\" > \"$lock_file\"'" \
     def remove(self, pkgs):
         return (self.exec_mock_cmd(["--remove"] + pkgs) == 0)
 
-    def init_and_install(self, srpm, pkgs, force_scrub=False, keep_going=False, try_only=False):
-        if force_scrub:
-            scrub_root_passes = [True]
-            # yet another hack for libguestfs/supermin
-            self.exec_mock_cmd(["--scrub=dnf-cache"], quiet=False)
-        else:
-            scrub_root_passes = [False, True]
-
-        for scrub_root in scrub_root_passes:
+    def init_and_install(self, srpm, pkgs, keep_going=False, try_only=False):
+        for scrub_root in [False, True]:
             if scrub_root and not self.scrub_done:
                 self.exec_mock_cmd(["--scrub=root-cache"], quiet=False)
                 self.scrub_done = True
@@ -1080,13 +1073,9 @@ the package.  Use --tools or --all-tools to enable them!\n", ec=0)
                     results.error("pre-mock hook failed", ec=rv)
 
             with MockWrapper(results, props) as mock:
-                supermin_in_use = False
                 if srpm_dup is not None:
-                    (ec, _) = results.get_cmd_output("rpm -qp '%s' --requires | grep '^supermin'" % srpm_dup)
-                    supermin_in_use = (ec == 0)
-
                     # first rebuild the given SRPM (some deps might be required even for the rebuild)
-                    mock.init_and_install(srpm_dup, props.install_pkgs, force_scrub=supermin_in_use, try_only=True)
+                    mock.init_and_install(srpm_dup, props.install_pkgs, try_only=True)
 
                     # install the copied SRPM into the chroot
                     srpm_in = "/builddir/%s" % srpm_base

--- a/py/csmock
+++ b/py/csmock
@@ -351,7 +351,8 @@ echo \"$self_pid\" > \"$lock_file\"'" \
             cmd = ["--install", "module-build-macros"] + cmd_add
             self.exec_mock_cmd(cmd, quiet=quiet)
 
-        cmd = ["--installdeps", srpm] + cmd_add
+        # install both static and dynamic build dependencies (replacement for --installdeps)
+        cmd = ["--calculate-build-dependencies", srpm] + cmd_add
         return (self.exec_mock_cmd(cmd, quiet=quiet) == 0)
 
     def emergency_install_pkgs(self, pkgs):
@@ -386,7 +387,7 @@ echo \"$self_pid\" > \"$lock_file\"'" \
                 continue
             self.init_done = True
 
-            # run `mock --installdeps`
+            # run `mock --calculate-build-dependencies`
             srpm_deps_ok = srpm is None or self.install_deps(srpm)
             if not srpm_deps_ok and not try_only:
                 srpm_base = os.path.basename(srpm)

--- a/py/csmock
+++ b/py/csmock
@@ -364,10 +364,10 @@ echo \"$self_pid\" > \"$lock_file\"'" \
         return (self.exec_mock_cmd(["--remove"] + pkgs) == 0)
 
     def init_and_install(self, srpm, pkgs, keep_going=False, try_only=False):
-        for scrub_root in [False, True]:
-            if scrub_root and not self.scrub_done:
-                self.results.print_with_ts("trying to scrub cache...")
-                self.exec_mock_cmd(["--scrub=root-cache"], quiet=False)
+        for do_scrub in [False, True]:
+            if do_scrub and not self.scrub_done:
+                self.results.print_with_ts("trying to scrub everything...")
+                self.exec_mock_cmd(["--scrub=all"], quiet=False)
                 self.scrub_done = True
                 self.init_done = False
 

--- a/py/csmock
+++ b/py/csmock
@@ -363,10 +363,6 @@ echo \"$self_pid\" > \"$lock_file\"'" \
     def remove(self, pkgs):
         return (self.exec_mock_cmd(["--remove"] + pkgs) == 0)
 
-    def copy_in_resolv_conf(self):
-        resconf = "/etc/resolv.conf"
-        return (self.exec_mock_cmd(["--copyin", resconf, resconf]) == 0)
-
     def init_and_install(self, srpm, pkgs, force_scrub=False, keep_going=False, try_only=False):
         if force_scrub:
             scrub_root_passes = [True]
@@ -1129,10 +1125,6 @@ the package.  Use --tools or --all-tools to enable them!\n", ec=0)
 
                 # make /builddir writable without root access
                 mock.exec_chroot_cmd("chown mockbuild -R /builddir")
-
-                if supermin_in_use:
-                    # attempt to make name resolving work in the chroot
-                    mock.copy_in_resolv_conf()
 
                 if props.shell_cmd_to_build is not None:
                     # prepare a build script in our tmp dir

--- a/py/csmock
+++ b/py/csmock
@@ -366,29 +366,27 @@ echo \"$self_pid\" > \"$lock_file\"'" \
     def init_and_install(self, srpm, pkgs, keep_going=False, try_only=False):
         for scrub_root in [False, True]:
             if scrub_root and not self.scrub_done:
+                self.results.print_with_ts("trying to scrub cache...")
                 self.exec_mock_cmd(["--scrub=root-cache"], quiet=False)
                 self.scrub_done = True
                 self.init_done = False
 
+            # unless a scrub was done print warnings only
+            ec_by_scrub = int(self.scrub_done)
+
             # run `mock --init` if not disabled
             if not self.init_done and (self.exec_mock_cmd(["--init"], quiet=False) != 0):
-                if scrub_root:
-                    self.results.fatal_error("failed to init mock profile (%s)" % self.mock_profile)
-                else:
-                    self.results.error("failed to init mock profile (%s), trying to scrub cache..." \
-                            % self.mock_profile, ec=0)
-                    continue
+                self.results.error(f"failed to init mock profile ({self.mock_profile})",
+                                   ec=ec_by_scrub, fatal=ec_by_scrub)
+                continue
             self.init_done = True
 
             # run `mock --installdeps`
             srpm_deps_ok = srpm is None or self.install_deps(srpm)
             if not srpm_deps_ok and not try_only:
                 srpm_base = os.path.basename(srpm)
-                if self.scrub_done:
-                    self.results.error("failed to install build dependencies of %s" % srpm_base)
-                else:
-                    self.results.error("failed to install build dependencies of %s, trying to scrub cache..." \
-                            % srpm_base, ec=0)
+                self.results.error(f"failed to install build dependencies of {srpm_base}", ec=ec_by_scrub)
+                if not self.scrub_done:
                     continue
 
                 if keep_going:
@@ -406,13 +404,8 @@ echo \"$self_pid\" > \"$lock_file\"'" \
             if try_only:
                 return False
 
-            if self.scrub_done:
-                self.results.error("failed to install required packages (%s)" % strlist_to_shell_cmd(missing_deps))
-                return False
-            else:
-                self.results.error("failed to install required packages (%s), trying to scrub cache..." \
-                        % strlist_to_shell_cmd(missing_deps), ec=0)
-                continue
+            self.results.error(f"failed to install required packages ({strlist_to_shell_cmd(missing_deps)})",
+                               ec=ec_by_scrub)
 
         return False
 

--- a/py/plugins/snyk.py
+++ b/py/plugins/snyk.py
@@ -148,13 +148,6 @@ class Plugin:
         # fetch snyk binary executable before initializing the buildroot
         props.pre_mock_hooks += [fetch_snyk_hook]
 
-        # make networking work in the chroot
-        def copy_resolv_conf(results, mock):
-            mock.copy_in_resolv_conf()
-            return 0
-
-        props.post_depinst_hooks += [copy_resolv_conf]
-
         def scan_hook(results, mock, props):
             # copy snyk authentication token into the chroot
             dst_dir = "/builddir/.config/configstore"


### PR DESCRIPTION
Use the `--calculate-build-dependencies` option of `mock` instead of the `--installdeps` option, which installs static build dependencies only.

Fixes: https://github.com/csutils/csmock/issues/188