### PR TITLE
csmock: run `--calculate-build-dependencies` with `--no-clean`

### DIFF
--- a/py/csmock
+++ b/py/csmock
@@ -352,7 +352,7 @@ echo \"$self_pid\" > \"$lock_file\"'" \
             self.exec_mock_cmd(cmd, quiet=quiet)
 
         # install both static and dynamic build dependencies (replacement for --installdeps)
-        cmd = ["--calculate-build-dependencies", srpm] + cmd_add
+        cmd = ["--no-clean", "--calculate-build-dependencies", srpm] + cmd_add
         return (self.exec_mock_cmd(cmd, quiet=quiet) == 0)
 
     def emergency_install_pkgs(self, pkgs):


### PR DESCRIPTION
... to avoid recreating the buildroot from scratch on each invocation

Fixes: https://github.com/csutils/csmock/pull/189
Closes: https://github.com/csutils/csmock/pull/190