### PR TITLE
csmock: support buildroot location used by new `rpm`

### DIFF
--- a/py/common/util.py
+++ b/py/common/util.py
@@ -139,7 +139,9 @@ def dirs_to_scan_by_args(parser, args, props, tool):
         dirs_to_scan += ["/builddir/build/BUILD"]
 
     if scan_install:
-        dirs_to_scan += ["/builddir/build/BUILDROOT"]
+        # the second variant was introduced by a backward-incompatible change in `rpm`
+        # https://github.com/rpm-software-management/rpm/commit/9d35c8df497534e1fbd806a4dc78802bcf35d7cb
+        dirs_to_scan += ["/builddir/build/BUILDROOT", "/builddir/build/BUILD/*/BUILDROOT"]
         props.need_rpm_bi = True
 
     return ' '.join(dirs_to_scan)

--- a/py/common/util.py
+++ b/py/common/util.py
@@ -129,24 +129,20 @@ def dirs_to_scan_by_args(parser, args, props, tool):
         scan_install = (props.shell_cmd_to_build is None)
 
     if not scan_build and not scan_install:
-        parser.error("either --%s-scan-build or --%s-scan-install must be enabled" %
-                     (tool, tool))
+        parser.error(f"either --{tool}-scan-build or --{tool}-scan-install must be enabled")
 
     if scan_install and (props.shell_cmd_to_build is not None):
-        parser.error("--shell-cmd and --%s-scan-install cannot be used together" %
-                     tool)
+        parser.error(f"--shell-cmd and --{tool}-scan-install cannot be used together")
 
-    dirs_to_scan = ""
+    dirs_to_scan = []
     if scan_build:
-        dirs_to_scan += "/builddir/build/BUILD"
-        if scan_install:
-            dirs_to_scan += " "
+        dirs_to_scan += ["/builddir/build/BUILD"]
 
     if scan_install:
-        dirs_to_scan += "/builddir/build/BUILDROOT"
+        dirs_to_scan += ["/builddir/build/BUILDROOT"]
         props.need_rpm_bi = True
 
-    return dirs_to_scan
+    return ' '.join(dirs_to_scan)
 
 
 def require_file(parser, name):

--- a/py/csmock
+++ b/py/csmock
@@ -94,7 +94,10 @@ DEFAULT_RESULT_FILTERS = [
 
 # path filter needed with `rpmbuild -bi`
 # TODO: introduce a csgrep option for this
-RPM_BI_FILTER = "sed 's|/builddir/build/BUILDROOT/[^/]*/|/builddir/build/BUILD//|'"
+# `/builddir/build/BUILDROOT/${NVR}/...` was used by old versions of `rpm`
+# `/builddir/build/BUILD/${NVR}/BUILDROOT/...` was later introduced by a backward-incompatible change in `rpm`
+# https://github.com/rpm-software-management/rpm/commit/9d35c8df497534e1fbd806a4dc78802bcf35d7cb
+RPM_BI_FILTER = "sed -r 's;/builddir/build/BUILD(ROOT/[^/]+|/[^/]+/BUILDROOT)/;/builddir/build/BUILD//;'"
 
 # path to csexec-loader is hard-coded for now
 CSEXEC_ENABLE_FLAG = "-Wl,--dynamic-linker,/usr/bin/csexec-loader"

--- a/py/plugins/bandit.py
+++ b/py/plugins/bandit.py
@@ -63,7 +63,7 @@ class Plugin:
         props.install_pkgs += ["bandit"]
 
         severity_filter = dict(zip(self._severity_levels, ['-l', '-ll', '-lll']))[args.bandit_severity_filter.upper()]
-        run_cmd = "%s %s %s > %s" % (RUN_BANDIT_SH, severity_filter, dirs_to_scan, BANDIT_CAPTURE)
+        run_cmd = f"shopt -s nullglob && {RUN_BANDIT_SH} {severity_filter} {dirs_to_scan} > {BANDIT_CAPTURE}"
         props.post_build_chroot_cmds += [run_cmd]
         props.copy_out_files += [BANDIT_CAPTURE]
 

--- a/py/plugins/pylint.py
+++ b/py/plugins/pylint.py
@@ -58,7 +58,7 @@ class Plugin:
             parser, args, props, "pylint")
 
         props.install_pkgs += ["pylint"]
-        cmd = "%s %s > %s" % (RUN_PYLINT_SH, dirs_to_scan, PYLINT_CAPTURE)
+        cmd = f"shopt -s nullglob && {RUN_PYLINT_SH} {dirs_to_scan} > {PYLINT_CAPTURE}"
         props.post_build_chroot_cmds += [cmd]
         props.copy_out_files += [PYLINT_CAPTURE]
 

--- a/py/plugins/shellcheck.py
+++ b/py/plugins/shellcheck.py
@@ -75,7 +75,8 @@ class Plugin:
         dirs_to_scan = " ".join([dir + "/*" for dir in dirs_to_scan.split()])
 
         props.install_pkgs += ["ShellCheck"]
-        cmd = f"SC_RESULTS_DIR={SHELLCHECK_CAP_DIR} "
+        cmd = "shopt -s nullglob && "
+        cmd += f"SC_RESULTS_DIR={SHELLCHECK_CAP_DIR} "
         cmd += f"SC_BATCH={args.shellcheck_batch} "
         cmd += f"SC_TIMEOUT={args.shellcheck_timeout} "
         cmd += f"{RUN_SHELLCHECK_SH} {dirs_to_scan}"


### PR DESCRIPTION
The `%{buildroot}` directory we were looking into is no longer used by new versions of `rpm`.  The directory was moved with the following backward-incompatible change: https://github.com/rpm-software-management/rpm/commit/9d35c8df497534e1fbd806a4dc78802bcf35d7cb

This commit makes csmock look into both the locations.

Fixes: https://github.com/csutils/csmock/issues/191