### PR TITLE
scripts: suppress ShellCheck false positives

### DIFF
--- a/scripts/run-scan.sh
+++ b/scripts/run-scan.sh
@@ -25,7 +25,7 @@ BUILD_CMD="$2"
 test -n "$BUILD_CMD" || die "no BUILD_CMD given"
 
 FILTER_CMD="$3"
-test -n "$FILTER_CMD" || FILTER_CMD=cat
+test -n "$FILTER_CMD" || FILTER_CMD="cat"
 
 BASE_ERR="$4"
 if test -n "$BASE_ERR"; then

--- a/scripts/run-shellcheck.sh
+++ b/scripts/run-shellcheck.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC2319
+
 export LC_ALL="C"
 
 # how many shell scripts we pass to shellcheck at a time


### PR DESCRIPTION
Detected by OpenScanHub:
https://openscanhub.fedoraproject.org/task/21451/log/csmock-3.7.1.20241107.141738.gf0a5aed.pr_187-1/scan-results.html
```
Error: SHELLCHECK_WARNING (CWE-456):
/usr/share/csbuild/scripts/run-scan.sh:28:26: warning[SC2209]: Use var=$(command) to assign output (or quote to assign string).
 #   26|
 #   27|   FILTER_CMD="$3"
 #   28|-> test -n "$FILTER_CMD" || FILTER_CMD=cat
 #   29|
 #   30|   BASE_ERR="$4"

Error: SHELLCHECK_WARNING:
/usr/share/csmock/scripts/run-shellcheck.sh:14:34: warning[SC2319]: This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
 #   12|   # how long we wait (wall-clock time) for a single shellcheck process to finish
 #   13|   test -n "$SC_TIMEOUT" || export SC_TIMEOUT=30
 #   14|-> test 0 -lt "$SC_TIMEOUT" || exit $?
 #   15|
 #   16|   # directory for shellcheck results
```