### PR TITLE
csmock: use `--installdeps` for legacy chroots

### DIFF
--- a/py/csmock
+++ b/py/csmock
@@ -354,8 +354,15 @@ echo \"$self_pid\" > \"$lock_file\"'" \
             cmd = ["--install", "module-build-macros"] + cmd_add
             self.exec_mock_cmd(cmd, quiet=quiet)
 
-        # install both static and dynamic build dependencies (replacement for --installdeps)
-        cmd = ["--no-clean", "--calculate-build-dependencies", srpm] + cmd_add
+        if "rhel-7" in self.mock_profile:
+            # use --installdeps for legacy chroots
+            base_cmd = "--installdeps"
+        else:
+            # install both static and dynamic build dependencies (replacement for --installdeps)
+            base_cmd = "--calculate-build-dependencies"
+
+        # finally install the dependencies
+        cmd = ["--no-clean", base_cmd, srpm] + cmd_add
         return (self.exec_mock_cmd(cmd, quiet=quiet) == 0)
 
     def emergency_install_pkgs(self, pkgs):

--- a/tests/simple_build/test.sh
+++ b/tests/simple_build/test.sh
@@ -50,7 +50,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Analyze $TEST_PACKAGE using $TEST_TOOL"
-        rlRun "su - $TEST_USER -c 'csmock -t $TEST_TOOL $CSMOCK_EXTRA_OPTS \"$SRPM\" --install pam'" 0 \
+        rlRun "su - $TEST_USER -c 'csmock -t $TEST_TOOL $CSMOCK_EXTRA_OPTS \"$SRPM\" --install pam --gcc-add-flag=-std=gnu11'" 0 \
             "Analyze $SRPM using $TEST_TOOL analyzer"
         rlFileSubmit "/home/$TEST_USER/$TEST_PACKAGE"*.tar.xz "$SRPM-$TEST_TOOL.tar.xz"
     rlPhaseEnd

--- a/tests/simple_build/test.sh
+++ b/tests/simple_build/test.sh
@@ -50,7 +50,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Analyze $TEST_PACKAGE using $TEST_TOOL"
-        rlRun "su - $TEST_USER -c 'csmock -t $TEST_TOOL $CSMOCK_EXTRA_OPTS \"$SRPM\"'" 0 \
+        rlRun "su - $TEST_USER -c 'csmock -t $TEST_TOOL $CSMOCK_EXTRA_OPTS \"$SRPM\" --install pam'" 0 \
             "Analyze $SRPM using $TEST_TOOL analyzer"
         rlFileSubmit "/home/$TEST_USER/$TEST_PACKAGE"*.tar.xz "$SRPM-$TEST_TOOL.tar.xz"
     rlPhaseEnd


### PR DESCRIPTION
RHEL-7 packages do not use dynamic build dependencies and the new way to install build dependencies breaks build/scan in some cases, such as with `ipa-4.6.5-11.el7_7.4`.

Fixes: commit 50b1c8c7b5de0ba8befc832f3b29940524cdb325
Related: https://github.com/csutils/csmock/issues/188