### PR TITLE
shellcheck: improve handling of ShellCheck internal errors

### DIFF
--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -3,6 +3,7 @@
 name: Differential ShellCheck
 on:
   push:
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 


### PR DESCRIPTION
Rather than failing the whole scan, record them in the scan results.

Reproducer:
```
csmock -r rhel-7.7.z-x86_64 -f pki-core-10.5.16-7.el7_7.src.rpm -t shellcheck
```

This commit makes the above scan succeed with the following additional finding included in the scan results:
```
Error: SHELLCHECK_WARNING:
/usr/sbin/pki-server-nuxwdog: internal error: hGetContents: invalid argument (invalid byte sequence)
```