### PR TITLE
pylint: modernize the `run-pylint.sh` script

### DIFF
--- a/scripts/run-pylint.sh
+++ b/scripts/run-pylint.sh
@@ -1,11 +1,41 @@
-#!/bin/sh
+#!/bin/bash
+# shellcheck disable=SC2317
+
 export LC_ALL="C"
 
+# this output format was used by Prospector
+export MSG_TEMPLATE='{abspath}:{line}:{column}: {msg_id}[pylint]: {msg}'
+
+# implementation of the script that filters python scripts
+filter_python_scripts() {
+    for i in "$@"; do
+        # match by file name suffix
+        if [[ "$i" =~ ^.*\.py$ ]]; then
+            echo "$i"
+            echo -n . >&2
+            continue
+        fi
+
+        # match by shebang (executable files only)
+        RE_SHEBANG='^#!.*python[0-9.]*'
+        if test -x "$i" && head -n1 "$i" | grep -q --text "$RE_SHEBANG"; then
+            echo "$i"
+            echo -n . >&2
+        fi
+    done
+}
+
+# store a script that filters python scripts to a variable
+FILTER_SCRIPT="$(declare -f filter_python_scripts)
+filter_python_scripts"' "$@"'
+
+# find all python scripts and run pylint on them
+echo -n "Looking for python scripts..." >&2
 find "$@" -type f -print0 \
-    | xargs -0 sh -c 'for i in "$@"; do { printf "%s\n" "$i" | grep "\\.py\$" \
-        || head -n1 "$i" | grep --text "^#!.*python"
-        } >/dev/null && readlink -f "$i"; done' "$0" \
-    | sort -V | tee /dev/fd/2 \
-    | xargs -r pylint -rn --msg-template '{abspath}:{line}:{column}: {msg_id}[pylint]: {msg}' \
-    | grep --invert-match '^\** Module ' \
-    | tee /dev/fd/2
+    | xargs -0 /bin/bash -c "$FILTER_SCRIPT" "$0" \
+    | { sort -uV && echo " done" >&2; } \
+    | xargs -r /bin/bash -xc 'pylint -rn --msg-template "${MSG_TEMPLATE}" "$@"' "$0" \
+    | grep --invert-match '^\** Module '
+
+# propagage the exit status from the second xargs
+exit "${PIPESTATUS[3]}"


### PR DESCRIPTION
... to make it work the same way as `run-shellcheck.sh` works now.

Given the fact that `pylint` is not enabled by default, the `run-pylint.sh` script has not been actively maintained.  This commit transfers the well-tested parts of code from `run-shellcheck.sh` to `run-pylint.sh`.