### PR TITLE
ci(shellcheck): use `sarif-fmt` as display engine

### DIFF
--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -28,9 +28,10 @@ jobs:
         name: Differential ShellCheck
         uses: redhat-plumbers-in-action/differential-shellcheck@v5
         with:
+          display-engine: sarif-fmt
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - if: ${{ always() }}
+      - if: ${{ runner.debug == '1' && !cancelled() }}
         name: Upload artifact with ShellCheck defects in SARIF format
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Also, upload the debugging SARIF artifact only when debug is enabled.

Example of difference between ShellCheck display engines: https://github.com/redhat-plumbers-in-action/differential-shellcheck?tab=readme-ov-file#display-engine