### PR TITLE
csmock: revert differences in source file paths

### DIFF
--- a/py/csmock
+++ b/py/csmock
@@ -87,6 +87,7 @@ DEFAULT_CSWRAP_FILTERS = [
 
 # remember to use --mode=json for csgrep (TODO: improve csgrep's interface)
 DEFAULT_RESULT_FILTERS = [
+    "sed -r 's|(/builddir/build/BUILD/)[^/]+-build/|\\1|'",
     "csgrep --mode=json --path '^/builddir/build/BUILD/' \
 --strip-path-prefix /builddir/build/BUILD/",
     "csgrep --mode=json --invert-match --path '^ksh-.*[0-9]+\\.c$'",


### PR DESCRIPTION
... introduced by newer versions of RPM in Fedora.  This is needed for previously recorded known-false-positives to work because they would not be matched with file paths like this (see the duplicated version string in the first two directory levels):
```
util-linux-2.42.start-build/util-linux-2.42.start/disk-utils/cfdisk.c:875:28: warning[-Wanalyzer-malloc-leak]: leak of ‘*m.ignore’
```