### PR TITLE
csmock: use `--installdeps` for rhel-6, too

### DIFF
--- a/csmock/csmock
+++ b/csmock/csmock
@@ -356,7 +356,7 @@ echo \"$self_pid\" > \"$lock_file\"'" \
             cmd = ["--install", "module-build-macros"] + cmd_add
             self.exec_mock_cmd(cmd, quiet=quiet)
 
-        if "rhel-7" in self.mock_profile:
+        if re.search(r"rhel-[67]", self.mock_profile):
             # use --installdeps for legacy chroots
             base_cmd = "--installdeps"
         else:


### PR DESCRIPTION
Related: https://github.com/csutils/csmock/pull/195
PR: https://github.com/csutils/csmock/pull/204