### PR TITLE
csmock: install SRPM as mockbuild user

### DIFF
--- a/csmock/csmock
+++ b/csmock/csmock
@@ -1171,7 +1171,7 @@ cd %%s*/ || cd *\n\
                 if not props.no_scan:
                     if props.shell_cmd_to_build is None:
                         # install the copied SRPM into the chroot
-                        mock.exec_chroot_cmd("rpm -Uvh --nodeps '%s'" % srpm_dup)
+                        mock.exec_mockbuild_cmd("rpm -Uvh --nodeps '%s'" % srpm_dup)
                         # make the installed SRPM accessible (if the maintainer did not)
                         mock.exec_chroot_cmd("chmod -R +r /builddir")
 


### PR DESCRIPTION
During a csmock run, there are two uses of `rpm -Uvh <srpm>` which install the sources into the build dir. The first runs as mockbuild user, whilst the second ran as root. This second run installed files owned by root, which could prevent some file operations performed during the rpm build from succeeding.

PSSECAUT-1201