### PR TITLE
CI: specify the programming language for Coverity

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -3,7 +3,9 @@ name: Coverity
 
 on:
   push:
-    branches: [main]
+    branches:
+      - coverity
+      - main
 
 jobs:
   coverity:
@@ -26,4 +28,4 @@ jobs:
           # The GitHub Action this workflow is based on uses `cov-build`, which
           # does not support buildless capture any more.  This way we make it
           # use `coverity capture` instead of `cov-build`.
-          command: --ident; set -x; coverity --ticker-mode=no-spin capture --dir=cov-int --file-include-regex="csmock|scripts"
+          command: --ident; set -x; coverity --ticker-mode=no-spin capture --dir=cov-int --file-include-regex="csmock|scripts" --language=python


### PR DESCRIPTION
Commit 2a9ee594097042a784289c41b2e9522ebe6de39c fixed the CI failure. Nevertheless the Coverity service still sends failure notifications about incomplete capture.  Explicitly specify the programming language to eliminate these failure notifications.

Also extend the trigger for this workflow to a branch named `coverity` so that we can esily test changes in the CI configuration by pushing updates to the upstream `coverity` branch.

Related: https://github.com/csutils/csmock/issues/207