### PR TITLE
`csmock --embed-context`: use `csgrep-static` in chroot

### DIFF
--- a/csmock/csmock
+++ b/csmock/csmock
@@ -49,6 +49,9 @@ CSMOCK_DATADIR = "/usr/share/csmock"
 
 CWE_MAP_FILE = CSMOCK_DATADIR + "/cwe-map.csv"
 
+# path to the csgrep-static executable
+CSGREP_STATIC = "/usr/libexec/csgrep-static"
+
 CSMOCK_SCRIPTS = CSMOCK_DATADIR + "/scripts"
 
 CHROOT_FIXUPS = CSMOCK_SCRIPTS + "/chroot-fixups"
@@ -958,8 +961,8 @@ exceeds the specified limit (defaults to 1024).")
     props.kfp_git_url           = args.kfp_git_url
 
     if props.embed_context > 0:
-        # we need 'csgrep --embed-context' to work in the chroot for --embed-context
-        props.install_opt_pkgs += ["csdiff"]
+        # we need csgrep-static in the chroot for --embed-context
+        props.copy_in_files += [CSGREP_STATIC]
 
     if args.warning_rate_limit > 0:
         props.results_limits_opts += [f"--warning-rate-limit={args.warning_rate_limit}"]
@@ -1289,7 +1292,7 @@ cd %%s*/ || cd *\n\
                 if props.embed_context > 0:
                     # embed context lines from source program files
                     tmp_file = f"{all_file}.tmp"
-                    csgrep_cmd = f"csgrep --mode=json --embed-context {props.embed_context}"
+                    csgrep_cmd = f"{CSGREP_STATIC} --mode=json --embed-context {props.embed_context}"
 
                     if props.results_limits_opts:
                         # apply results limits already while embedding context to avoid creating excessively huge output

--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -125,6 +125,7 @@ Tool for plugging static analyzers into the build process, free of mock.
 %package common
 Summary: Core of csmock (a mock wrapper for Static Analysis tools)
 Requires: csdiff > 3.5.1
+Requires: csdiff-static
 Requires: csgcca
 Requires: cswrap
 Requires: mock >= 5.7


### PR DESCRIPTION
... so that `csdiff` does not need to be available in build repos

Related: https://github.com/csutils/csdiff/pull/196
Related: https://github.com/csutils/csdiff/pull/239