### PR TITLE
gcc: use `-fanalyzer-assume-nothrow` with `--gcc-analyze`

### DIFF
--- a/csmock/plugins/gcc.py
+++ b/csmock/plugins/gcc.py
@@ -45,6 +45,7 @@ SANITIZER_CAPTURE_DIR = "/builddir/gcc-sanitizer-capture"
 
 # use the following flags only if they are supported by gcc in the chroot
 GCC_ANALYZER_NEW_FLAGS = [
+    "-fanalyzer-assume-nothrow",
     "-fdiagnostics-text-art-charset=none",
 ]
 


### PR DESCRIPTION
Use `-fanalyzer-assume-nothrow` with `--gcc-analyze` if the option is supported by gcc in the chroot.

Related: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=122623