### PR TITLE
feat(shellcheck): add SC_SKIP_JINJA option to skip Jinja2 templates

### DIFF
--- a/scripts/run-shellcheck.sh
+++ b/scripts/run-shellcheck.sh
@@ -15,6 +15,9 @@ export SC_JOBS
 test -n "$SC_TIMEOUT" || export SC_TIMEOUT=30
 test 0 -lt "$SC_TIMEOUT" || exit $?
 
+# skip files containing Jinja2 template syntax ({{ }}, {% %}, {# #})
+test -n "$SC_SKIP_JINJA" || export SC_SKIP_JINJA=0
+
 # directory for shellcheck results
 test -n "$SC_RESULTS_DIR" || export SC_RESULTS_DIR="./shellcheck-results"
 
@@ -62,7 +65,6 @@ filter_shell_scripts() {
         # match by file name suffix
         if [[ "$i" =~ ^.*\.(ash|bash|bats|dash|ksh|sh)$ ]]; then
             echo "$i"
-            echo -n . >&2
             continue
         fi
 
@@ -70,14 +72,26 @@ filter_shell_scripts() {
         RE_SHEBANG='^\s*((#|!)|(#\s*!)|(!\s*#))\s*(/usr(/local)?)?/bin/(env\s+)?(ash|bash|bats|dash|ksh|sh)\b'
         if test -x "$i" && head -n1 "$i" | grep -qE --text "$RE_SHEBANG"; then
             echo "$i"
-            echo -n . >&2
         fi
+    done
+}
+
+apply_exclusion() {
+    while read -r i; do
+        # skip Jinja2 templates if requested
+        if [ "$SC_SKIP_JINJA" -eq 1 ] && grep -qE '\{\{|\{%|\{#' "$i" 2>/dev/null; then
+            continue
+        fi
+
+        echo "$i"
+        echo -n . >&2
     done
 }
 
 # store a script that filters shell scripts to a variable
 FILTER_SCRIPT="$(declare -f filter_shell_scripts)
-filter_shell_scripts"' "$@"'
+$(declare -f apply_exclusion)
+filter_shell_scripts"' "$@" | apply_exclusion'
 
 # function that creates a separate JSON file if shellcheck detects anything
 wrap_shellcheck() {


### PR DESCRIPTION
ShellCheck cannot parse Jinja2 template syntax ({{ }}, {% %}, {# #}). Any file containing these constructs breaks the parser entirely, producing unreliable findings (SC1054, SC1073, SC1083). Setting SC_SKIP_JINJA=1 causes filter_shell_scripts() to exclude these files before they reach shellcheck. Disabled by default so existing behavior is unchanged.

Tested against https://github.com/openshift/cac-content-fork where findings dropped from 11,776 to 43 (99.6% noise reduction).

Resolves: PSSECAUT-1577